### PR TITLE
Mysql2 support and remove_foreign_key

### DIFF
--- a/lib/rein.rb
+++ b/lib/rein.rb
@@ -9,6 +9,7 @@ require 'active_record'
 require 'active_support/core_ext/hash'
 
 require 'rein/constraint/foreign_key'
+require 'rein/constraint/mysql_remove_foreign_key'
 require 'rein/constraint/primary_key'
 require 'rein/constraint/inclusion'
 require 'rein/constraint/numericality'
@@ -18,12 +19,14 @@ module ActiveRecord::ConnectionAdapters
   class MysqlAdapter < AbstractAdapter
     include RC::PrimaryKey
     include RC::ForeignKey
+    include RC::MysqlRemoveForeignKey
     include Rein::View
   end
 
   class Mysql2Adapter < AbstractAdapter
     include RC::PrimaryKey
     include RC::ForeignKey
+    include RC::MysqlRemoveForeignKey
     include Rein::View
   end
 

--- a/lib/rein/constraint/mysql_remove_foreign_key.rb
+++ b/lib/rein/constraint/mysql_remove_foreign_key.rb
@@ -1,0 +1,12 @@
+module RC
+  module MysqlRemoveForeignKey
+    def remove_foreign_key_constraint(referencing_table, column_name)
+      index_name = "#{column_name}_fk"
+      execute "ALTER TABLE #{referencing_table} DROP FOREIGN KEY #{index_name}"
+      remove_index :atc_applications, :name => index_name.to_s
+    end
+
+    alias_method :remove_foreign_key, :remove_foreign_key_constraint
+
+  end
+end


### PR DESCRIPTION
Rein currently crashes with the new mysql2 gem, as in lib/rein.rb only the original MysqlAdapter is used.

As a extra treat we added a remove_foreign_key method for MySQL as an alternative to manually executing the "ALTER TABLE ... DROP FOREIGN KEY" and then removing the index. 
