### PR TITLE
Feature: Added option to name the referenced attribute in add_foreign_key_constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,17 +7,17 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.0.3)
-      activesupport (= 3.0.3)
+    activemodel (3.0.5)
+      activesupport (= 3.0.5)
       builder (~> 2.1.2)
       i18n (~> 0.4)
-    activerecord (3.0.3)
-      activemodel (= 3.0.3)
-      activesupport (= 3.0.3)
+    activerecord (3.0.5)
+      activemodel (= 3.0.5)
+      activesupport (= 3.0.5)
       arel (~> 2.0.2)
       tzinfo (~> 0.3.23)
-    activesupport (3.0.3)
-    arel (2.0.7)
+    activesupport (3.0.5)
+    arel (2.0.9)
     builder (2.1.2)
     diff-lcs (1.1.2)
     hirb (0.3.6)
@@ -33,7 +33,7 @@ GEM
     rspec-expectations (2.4.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.4.0)
-    tzinfo (0.3.24)
+    tzinfo (0.3.25)
     wirble (0.1.3)
 
 PLATFORMS

--- a/lib/rein/constraint/foreign_key.rb
+++ b/lib/rein/constraint/foreign_key.rb
@@ -1,10 +1,10 @@
 module RC
   module ForeignKey
     def add_foreign_key_constraint(referencing_table, referenced_table, options = {})
-      referencing_attribute = options[:referencing] || "#{referenced_table.to_s.singularize}_id".to_sym
-      referenced_attribute  = "id".to_sym
+      referencing_attribute = (options[:referencing] || "#{referenced_table.to_s.singularize}_id").to_sym
+      referenced_attribute  = (options[:referenced] || "id").to_sym
 
-      name = options[:name] || "#{referencing_attribute}_fk".to_sym
+      name = (options[:name] || "#{referencing_attribute}_fk").to_sym
 
       sql = "ALTER TABLE #{referencing_table}".tap do |sql|
         sql << " ADD CONSTRAINT #{name}"

--- a/spec/rein/constraint/foreign_key_spec.rb
+++ b/spec/rein/constraint/foreign_key_spec.rb
@@ -25,6 +25,16 @@ describe RC::ForeignKey do
       it { should have_received.execute("ALTER TABLE books ADD CONSTRAINT author_id_fk FOREIGN KEY (author_id) REFERENCES people (id) ON DELETE RESTRICT ON UPDATE RESTRICT") }
     end
 
+    context "with a given referenced attribute" do
+      before { adapter.add_foreign_key_constraint(:books, :people, :referenced => :person_id) }
+      it { should have_received.execute("ALTER TABLE books ADD CONSTRAINT person_id_fk FOREIGN KEY (person_id) REFERENCES people (person_id) ON DELETE RESTRICT ON UPDATE RESTRICT") }
+    end
+
+    context "with a given referencing attribute and referenced attribute" do
+      before { adapter.add_foreign_key_constraint(:books, :people, :referencing => :author_id, :referenced => :person_id) }
+      it { should have_received.execute("ALTER TABLE books ADD CONSTRAINT author_id_fk FOREIGN KEY (author_id) REFERENCES people (person_id) ON DELETE RESTRICT ON UPDATE RESTRICT") }
+    end
+
     context "with a given name" do
       before { adapter.add_foreign_key_constraint(:books, :people, :name => :foo) }
       it { should have_received.execute("ALTER TABLE books ADD CONSTRAINT foo FOREIGN KEY (person_id) REFERENCES people (id) ON DELETE RESTRICT ON UPDATE RESTRICT") }


### PR DESCRIPTION
Instead of hardcoding the referenced attribute in the foreign table to "id".to_sym you can now name the attribute via the :referenced option. 

Added two tests showcasing the new feature. 

Cheers 
Marc
