### PR TITLE
Change default constraint name to be unique across database

### DIFF
--- a/lib/rein/constraint/foreign_key.rb
+++ b/lib/rein/constraint/foreign_key.rb
@@ -4,7 +4,7 @@ module RC
       referencing_attribute = (options[:referencing] || "#{referenced_table.to_s.singularize}_id").to_sym
       referenced_attribute  = (options[:referenced] || "id").to_sym
 
-      name = (options[:name] || "#{referencing_table}_#{referencing_attribute}_fk").to_sym
+      name = options[:name] || default_constraint_name(referencing_table, referencing_attribute)
 
       sql = "ALTER TABLE #{referencing_table}".tap do |sql|
         sql << " ADD CONSTRAINT #{name}"
@@ -24,7 +24,7 @@ module RC
     def remove_foreign_key_constraint(referencing_table, referenced_table, options = {})
       referencing_attribute = options[:referencing] || "#{referenced_table.to_s.singularize}_id".to_sym
 
-      name = options[:name] || "#{referencing_attribute}_fk".to_sym
+      name = options[:name] || default_constraint_name(referencing_table, referencing_attribute)
 
       if is_a_mysql_adapter?
         execute "ALTER TABLE #{referencing_table} DROP FOREIGN KEY #{name}"
@@ -57,6 +57,10 @@ module RC
 
     def is_a_mysql_adapter?
       self.class.to_s =~ /Mysql[2]?Adapter/
+    end
+
+    def default_constraint_name(referencing_table, referencing_attribute)
+      "#{referencing_table}_#{referencing_attribute}_fk".to_sym
     end
   end
 end

--- a/spec/rein/constraint/foreign_key_spec.rb
+++ b/spec/rein/constraint/foreign_key_spec.rb
@@ -81,12 +81,12 @@ describe RC::ForeignKey do
 
     context "with no options" do
       before { adapter.remove_foreign_key_constraint(:books, :people) }
-      it { should have_received.execute("ALTER TABLE books DROP CONSTRAINT person_id_fk") }
+      it { should have_received.execute("ALTER TABLE books DROP CONSTRAINT books_person_id_fk") }
     end
 
     context "with a given referencing attribute" do
       before { adapter.remove_foreign_key_constraint(:books, :people, :referencing => :author_id) }
-      it { should have_received.execute("ALTER TABLE books DROP CONSTRAINT author_id_fk") }
+      it { should have_received.execute("ALTER TABLE books DROP CONSTRAINT books_author_id_fk") }
     end
 
     context "with a given name" do


### PR DESCRIPTION
Postgres is happy with a non-unique constraint name as it is scoped to each table, however MSSQL (and others?) require a unique constraint name across a given database.

Following the rails convention when creating indices this is kept unique like so :

```
Model : Customer
Index on field : external_id

Auto generates : 
index_customers_on_external_id
```

This pull request makes the default naming convention for constraints follow this pattern.
