### PR TITLE
Enable to add primary key constraint to optional column

### DIFF
--- a/lib/rein/constraint/primary_key.rb
+++ b/lib/rein/constraint/primary_key.rb
@@ -1,7 +1,7 @@
 module RC
   module PrimaryKey
     def add_primary_key(table, options = {})
-      attribute = "id".to_sym
+      attribute = (options[:column] || "id").to_sym
       sql = "ALTER TABLE #{table} ADD PRIMARY KEY (#{attribute})"
       execute(sql)
     end

--- a/spec/rein/constraint/primary_key_spec.rb
+++ b/spec/rein/constraint/primary_key_spec.rb
@@ -15,4 +15,9 @@ describe RC::PrimaryKey, "#add_primary_key" do
     before { adapter.add_primary_key(:books) }
     it { should have_received(:execute).with("ALTER TABLE books ADD PRIMARY KEY (id)") }
   end
+
+  context "with 'column' option" do
+    before { adapter.add_primary_key(:books, column: :code) }
+    it { should have_received(:execute).with("ALTER TABLE books ADD PRIMARY KEY (code)") }
+  end
 end


### PR DESCRIPTION
Target column for `add_primary_key` was hard coding as "id".
But we often would like to make optional column as primary key, I enabled to specify `column` option.
