### PR TITLE
Add support for creating ENUM types

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ can easily tame the data in your database.
     * [Inclusion constraints](#inclusion-constraints)
     * [Numericality constraints](#numericality-constraints)
     * [Presence constraints](#presence-constraints)
+  * [Data types](#data-types)
+    * [ENUM](#enum)
   * [Example](#example)
   * [License](#license)
 
@@ -120,6 +122,18 @@ you want to ensure that there is an actual value for a string:
 
 ```ruby
 add_presence_constraint :books, :title
+```
+
+## Data types
+
+## ENUM
+
+*(PostgreSQL only)*
+
+An enum is a data type that has a static and ordered set of values.
+
+```ruby
+add_enum_type :book_type, ['paperback', 'hardcover']
 ```
 
 ## Example

--- a/lib/rein.rb
+++ b/lib/rein.rb
@@ -6,6 +6,7 @@ require "rein/constraint/foreign_key"
 require "rein/constraint/inclusion"
 require "rein/constraint/numericality"
 require "rein/constraint/presence"
+require "rein/type/enum"
 require "rein/view"
 
 module ActiveRecord
@@ -28,6 +29,7 @@ module ActiveRecord
       include Rein::Constraint::Inclusion
       include Rein::Constraint::Numericality
       include Rein::Constraint::Presence
+      include Rein::Type::Enum
       include Rein::View
     end
   end

--- a/lib/rein/type/enum.rb
+++ b/lib/rein/type/enum.rb
@@ -1,0 +1,19 @@
+require "active_record/connection_adapters/abstract/quoting"
+
+module Rein
+  module Type
+    # This module contains methods for defining enum types.
+    module Enum
+      include ActiveRecord::ConnectionAdapters::Quoting
+
+      def add_enum(enum_name, enum_values = [])
+        enum_values = enum_values.map { |value| quote(value) }.join(", ")
+        execute("CREATE TYPE #{enum_name} AS ENUM (#{enum_values})")
+      end
+
+      def remove_enum(enum_name)
+        execute("DROP TYPE #{enum_name}")
+      end
+    end
+  end
+end

--- a/lib/rein/type/enum.rb
+++ b/lib/rein/type/enum.rb
@@ -6,13 +6,17 @@ module Rein
     module Enum
       include ActiveRecord::ConnectionAdapters::Quoting
 
-      def add_enum(enum_name, enum_values = [])
+      def add_enum_type(enum_name, enum_values = [])
         enum_values = enum_values.map { |value| quote(value) }.join(", ")
         execute("CREATE TYPE #{enum_name} AS ENUM (#{enum_values})")
       end
 
-      def remove_enum(enum_name)
+      def remove_enum_type(enum_name)
         execute("DROP TYPE #{enum_name}")
+      end
+
+      def add_enum_value(enum_name, new_value)
+        execute("ALTER TYPE #{enum_name} ADD VALUE #{quote(new_value)}")
       end
     end
   end

--- a/spec/rein/type/enum_spec.rb
+++ b/spec/rein/type/enum_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+RSpec.describe Rein::Type::Enum do
+  let(:adapter) do
+    Class.new do
+      include Rein::Type::Enum
+    end.new
+  end
+
+  describe "#add_enum" do
+    subject { adapter }
+
+    before do
+      allow(adapter).to receive(:execute)
+    end
+
+    context "with name and fields" do
+      before { adapter.add_enum(:type, %w(paperback hardcover)) }
+      it { is_expected.to have_received(:execute).with("CREATE TYPE type AS ENUM ('paperback', 'hardcover')") }
+    end
+  end
+
+  describe "#remove_enum" do
+    subject { adapter }
+
+    before do
+      allow(adapter).to receive(:execute)
+    end
+
+    context "remove an enum" do
+      before { adapter.remove_enum(:type) }
+      it { is_expected.to have_received(:execute).with("DROP TYPE type") }
+    end
+  end
+end

--- a/spec/rein/type/enum_spec.rb
+++ b/spec/rein/type/enum_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Rein::Type::Enum do
     end
 
     context "add a value to an enum" do
-      before { adapter.add_enum_value(:book_type, 'ebook') }
+      before { adapter.add_enum_value(:book_type, "ebook") }
       it { is_expected.to have_received(:execute).with("ALTER TYPE book_type ADD VALUE 'ebook'") }
     end
   end

--- a/spec/rein/type/enum_spec.rb
+++ b/spec/rein/type/enum_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Rein::Type::Enum do
     end.new
   end
 
-  describe "#add_enum" do
+  describe "#add_enum_type" do
     subject { adapter }
 
     before do
@@ -15,12 +15,12 @@ RSpec.describe Rein::Type::Enum do
     end
 
     context "with name and fields" do
-      before { adapter.add_enum(:type, %w(paperback hardcover)) }
-      it { is_expected.to have_received(:execute).with("CREATE TYPE type AS ENUM ('paperback', 'hardcover')") }
+      before { adapter.add_enum_type(:book_type, %w(paperback hardcover)) }
+      it { is_expected.to have_received(:execute).with("CREATE TYPE book_type AS ENUM ('paperback', 'hardcover')") }
     end
   end
 
-  describe "#remove_enum" do
+  describe "#remove_enum_type" do
     subject { adapter }
 
     before do
@@ -28,8 +28,21 @@ RSpec.describe Rein::Type::Enum do
     end
 
     context "remove an enum" do
-      before { adapter.remove_enum(:type) }
-      it { is_expected.to have_received(:execute).with("DROP TYPE type") }
+      before { adapter.remove_enum_type(:book_type) }
+      it { is_expected.to have_received(:execute).with("DROP TYPE book_type") }
+    end
+  end
+
+  describe "#add_enum_value" do
+    subject { adapter }
+
+    before do
+      allow(adapter).to receive(:execute)
+    end
+
+    context "add a value to an enum" do
+      before { adapter.add_enum_value(:book_type, 'ebook') }
+      it { is_expected.to have_received(:execute).with("ALTER TYPE book_type ADD VALUE 'ebook'") }
     end
   end
 end


### PR DESCRIPTION
# reason for this change

ENUM types offer a lot of the advantages of inclusion constraints in terms of maintaining data consistency. There currently isn't, as far as I know, a gem that handles the management of postgres enums in migrations.

This new code creates a type instead of a constraint, but I still feel like it is in keeping with the spirit of this project.

# changes

- add support for creating enum types
- add support for remove enum types
- add support for adding values to enum types