### PR TITLE
presence constraint should reject more whitespace than just spaces

### DIFF
--- a/lib/rein/constraint/presence.rb
+++ b/lib/rein/constraint/presence.rb
@@ -6,7 +6,7 @@ module Rein
 
       def add_presence_constraint(table, attribute)
         name       = "#{table}_#{attribute}"
-        conditions = "#{attribute} !~ '^\s*$'"
+        conditions = "#{attribute} !~ '^\\s*$'"
         execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
       end
     end

--- a/spec/rein/constraint/presence_spec.rb
+++ b/spec/rein/constraint/presence_spec.rb
@@ -13,6 +13,6 @@ RSpec.describe Rein::Constraint::Presence, "#add_presence_constraint" do
 
   context "given a table and attribute" do
     before { adapter.add_presence_constraint(:books, :state) }
-    it { is_expected.to have_received(:execute).with("ALTER TABLE books ADD CONSTRAINT books_state CHECK (state !~ '^\s*$')") }
+    it { is_expected.to have_received(:execute).with("ALTER TABLE books ADD CONSTRAINT books_state CHECK (state !~ '^\\s*$')") }
   end
 end


### PR DESCRIPTION
The backslash here needs to be escaped, since it appears in a ruby double-quoted string:

    def add_presence_constraint(table, attribute)
      name       = "#{table}_#{attribute}"
      conditions = "#{attribute} !~ '^\s*$'"
      execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
    end

In Ruby, `\s` turns into a space character, as you can see:

```
2.3.3 :004 > puts "'\s'".bytes
39
32
39
```

Just to confirm, here is a constraint created by the gem:

```
Check constraints:
    "users_email" CHECK (email::text !~ '^ *$'::text)
```

This fix adds escaping so that the backslash survives into Postgres.

Also: it would be nice to have a new category of tests that actually generate the constraints and verify that they work as expected. That would have caught this bug. In my own gem [`db_leftovers`](https://github.com/pjungwir/db_leftovers) I have tests for MySQL and Postgres that only run if you have set up a database and made a configuration file pointing at it. Are you interested in a PR to add something similar to rein? 
