### PR TITLE
Added if option for presence constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ you want to ensure that there is an actual value for a string:
 add_presence_constraint :books, :title
 ```
 
+If you only want to enforce the constraint under certain conditions,
+you can pass an optional `if` option:
+
+```ruby
+add_presence_constraint :books, :isbn, if: "status = 'published'"
+```
+
 ## Data types
 
 ### Enumerated types

--- a/lib/rein/constraint/presence.rb
+++ b/lib/rein/constraint/presence.rb
@@ -4,9 +4,12 @@ module Rein
     module Presence
       include ActiveRecord::ConnectionAdapters::Quoting
 
-      def add_presence_constraint(table, attribute)
+      def add_presence_constraint(table, attribute, options = {})
         name       = "#{table}_#{attribute}"
         conditions = "#{attribute} !~ '^\\s*$'"
+        if options[:if].present?
+          conditions = "NOT (#{options[:if]}) OR (#{conditions})"
+        end
         execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
       end
     end

--- a/spec/rein/constraint/presence_spec.rb
+++ b/spec/rein/constraint/presence_spec.rb
@@ -15,4 +15,9 @@ RSpec.describe Rein::Constraint::Presence, "#add_presence_constraint" do
     before { adapter.add_presence_constraint(:books, :state) }
     it { is_expected.to have_received(:execute).with("ALTER TABLE books ADD CONSTRAINT books_state CHECK (state !~ '^\\s*$')") }
   end
+
+  context "given a table and attribute and if option" do
+    before { adapter.add_presence_constraint(:books, :isbn, if: "state = 'published'") }
+    it { is_expected.to have_received(:execute).with("ALTER TABLE books ADD CONSTRAINT books_isbn CHECK (NOT (state = 'published') OR (isbn !~ '^\\s*$'))") }
+  end
 end


### PR DESCRIPTION
This lets you say

    add_presence_constraint :books, :isbn, if: "status = 'published'"

And it will generate

    CHECK (NOT (status = 'published') OR (isbn !~ '^\s*$'))

The PR includes a test and README update.
