### PR TITLE
Added first test against a live Postgres database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 .yardoc
 Gemfile.lock
+/spec/config/database.yml

--- a/gemfiles/activerecord_4.gemfile.lock
+++ b/gemfiles/activerecord_4.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     rein (2.0.0)
       activerecord (>= 4.0.0, < 6)
+      activesupport (>= 4.0.0, < 6)
 
 GEM
   remote: http://rubygems.org/
@@ -29,8 +30,10 @@ GEM
     diff-lcs (1.3)
     i18n (0.8.1)
     minitest (5.10.1)
+    mysql2 (0.4.5)
     parser (2.4.0.0)
       ast (~> 2.2)
+    pg (0.20.0)
     powerpack (0.1.1)
     rainbow (2.2.1)
     rake (12.0.0)
@@ -67,10 +70,12 @@ DEPENDENCIES
   activerecord (~> 4.2.8)
   appraisal (~> 2.1)
   bundler (~> 1.14)
+  mysql2
+  pg
   rake (~> 12.0)
   rein!
   rspec (~> 3.5)
   rubocop (~> 0.47)
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/gemfiles/activerecord_5.gemfile.lock
+++ b/gemfiles/activerecord_5.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     rein (2.0.0)
       activerecord (>= 4.0.0, < 6)
+      activesupport (>= 4.0.0, < 6)
 
 GEM
   remote: http://rubygems.org/
@@ -28,8 +29,10 @@ GEM
     diff-lcs (1.3)
     i18n (0.8.1)
     minitest (5.10.1)
+    mysql2 (0.4.5)
     parser (2.4.0.0)
       ast (~> 2.2)
+    pg (0.20.0)
     powerpack (0.1.1)
     rainbow (2.2.1)
     rake (12.0.0)
@@ -66,10 +69,12 @@ DEPENDENCIES
   activerecord (~> 5.0.2)
   appraisal (~> 2.1)
   bundler (~> 1.14)
+  mysql2
+  pg
   rake (~> 12.0)
   rein!
   rspec (~> 3.5)
   rubocop (~> 0.47)
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/rein.gemspec
+++ b/rein.gemspec
@@ -18,10 +18,13 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activerecord", ">= 4.0.0", "< 6"
+  spec.add_runtime_dependency "activesupport", ">= 4.0.0", "< 6"
 
   spec.add_development_dependency "appraisal", "~> 2.1"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "rubocop", "~> 0.47"
+  spec.add_development_dependency "pg"
+  spec.add_development_dependency "mysql2"
 end

--- a/spec/config/database.yml.sample
+++ b/spec/config/database.yml.sample
@@ -1,0 +1,24 @@
+# Set this up by saying:
+#     postgres=# create user rein_test with password 'rein_test';
+#     postgres=# create database rein_test with owner rein_test;
+#     postgres=# grant all privileges on database rein_test to rein_test;
+postgres:
+  adapter: postgres
+  host: localhost
+  database: rein_test
+  username: rein_test
+  password: rein_test
+  encoding: utf8
+  template: template0
+
+# Set this up by saying:
+#     mysql> create database rein_test;
+#     mysql> grant all privileges on rein_test.* to rein_test@localhost identified by 'rein_test';
+mysql:
+  adapter: mysql2
+  host: localhost
+  database: rein_test
+  username: rein_test
+  password: rein_test
+  encoding: utf8
+  

--- a/spec/postgres/constraint/presence_spec.rb
+++ b/spec/postgres/constraint/presence_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+require "benchmark"
+
+class RequireAuthorIsPresentOnBooks < ActiveRecord::Migration
+  def change
+    create_table :books do |t|
+      t.string :author, null: false
+    end
+    add_presence_constraint :books, :author
+  end
+end
+
+class RequireIsbnIsPresentOnPublishedBooks < ActiveRecord::Migration
+  def change
+    create_table :books do |t|
+      t.string :status, null: false
+      t.string :isbn
+    end
+    add_presence_constraint :books, :isbn, if: "status = 'published'"
+  end
+end
+
+RSpec.describe Rein::Constraint::Presence do
+  if !test_db_configuration("postgres")
+    it "WARN: Skipping Postgres tests because no database found. Use spec/config/database.yml to configure one."
+
+  else
+    let!(:conn) { test_db_connection(test_db_configuration("postgres")) }
+
+    before(:each) do
+      migration.migrate(:up)
+    end
+    after(:each) do
+      conn.execute "DROP TABLE IF EXISTS books"
+    end
+
+    context "always" do
+      let(:migration) { RequireAuthorIsPresentOnBooks.new }
+
+      it "should allow books with an author" do
+        conn.execute "INSERT INTO books (author) VALUES ('Ernest Hemingway')"
+        expect(conn.select_value("SELECT COUNT(*) FROM books").to_i).to eq 1
+      end
+
+      it "should forbid books with a blank author" do
+        ["", "  ", "\t", "\n"].each do |author|
+          expect {
+            conn.execute "INSERT INTO books (author) VALUES ('#{author}')"
+          }.to raise_error ActiveRecord::StatementInvalid
+        end
+      end
+    end
+
+    context "with if option" do
+      let(:migration) { RequireIsbnIsPresentOnPublishedBooks.new }
+
+      it "should allow books with an isbn" do
+        conn.execute "INSERT INTO books (status, isbn) VALUES ('published', '0374528373')"
+        expect(conn.select_value("SELECT COUNT(*) FROM books").to_i).to eq 1
+      end
+
+      it "should allow unpublished books with a blank isbn" do
+        conn.execute "INSERT INTO books (status, isbn) VALUES ('unpublished', '')"
+        expect(conn.select_value("SELECT COUNT(*) FROM books").to_i).to eq 1
+      end
+
+      it "should forbid published books with a blank isbn" do
+        ["", "  ", "\t", "\n"].each do |isbn|
+          expect {
+            conn.execute "INSERT INTO books (status, isbn) VALUES ('published', '#{isbn}')"
+          }.to raise_error ActiveRecord::StatementInvalid
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 
 require "rein"
+require "yaml"
 
 RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
@@ -16,4 +17,16 @@ RSpec.configure do |config|
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
   config.disable_monkey_patching!
+end
+
+def test_db_connection(conf)
+  ActiveRecord::Base.establish_connection(conf)
+  ActiveRecord::Base.connection
+end
+
+def test_db_configuration(database)
+  y = YAML.safe_load(File.open(File.join(File.expand_path(File.dirname(__FILE__)), "config", "database.yml")))
+  y[database]
+rescue Errno::ENOENT
+  nil
 end


### PR DESCRIPTION
Here is a test that creates actual presence constraints in a Postgres database and makes sure they behave as expected. If the user doesn't have a `spec/config/postgres.yml` file, it skips the tests but shows a `pending` message for them.

If this looks good, I'll add tests for other constraint types too, including for MySQL where supported.