### PR TITLE
Factor 'if' option handling into a separate module shared by all constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ To remove an inclusion constraint:
 remove_inclusion_constraint :books, :state
 ```
 
+You may also include an `if` option to enforce the constraint only under certain conditions,
+like so:
+
+```ruby
+add_inclusion_constraint :books, :state, in: %w(available on_loan),
+                                         if: "deleted_at IS NULL"
+```
+
 ### Numericality constraints
 
 *(PostgreSQL only)*

--- a/lib/rein.rb
+++ b/lib/rein.rb
@@ -1,6 +1,7 @@
 require "active_record"
 require "active_record/connection_adapters/abstract_mysql_adapter"
 
+require "rein/constraint/options"
 require "rein/constraint/primary_key"
 require "rein/constraint/foreign_key"
 require "rein/constraint/inclusion"

--- a/lib/rein/constraint/inclusion.rb
+++ b/lib/rein/constraint/inclusion.rb
@@ -5,11 +5,12 @@ module Rein
     # This module contains methods for defining inclusion constraints.
     module Inclusion
       include ActiveRecord::ConnectionAdapters::Quoting
+      include Rein::Constraint::Options
 
       def add_inclusion_constraint(table, attribute, options = {})
         name = "#{table}_#{attribute}"
         values = options[:in].map { |value| quote(value) }.join(", ")
-        conditions = "#{attribute} IN (#{values})"
+        conditions = conditions_with_if("#{attribute} IN (#{values})", options)
         execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
       end
 

--- a/lib/rein/constraint/numericality.rb
+++ b/lib/rein/constraint/numericality.rb
@@ -2,6 +2,8 @@ module Rein
   module Constraint
     # This module contains methods for defining numericality constraints.
     module Numericality
+      include Rein::Constraint::Options
+
       OPERATORS = {
         greater_than: :>,
         greater_than_or_equal_to: :>=,
@@ -19,9 +21,7 @@ module Rein
           [attribute, operator, value].join(" ")
         end.join(" AND ")
 
-        if options[:if].present?
-          conditions = "NOT (#{options[:if]}) OR (#{conditions})"
-        end
+        conditions = conditions_with_if(conditions, options)
 
         execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
       end

--- a/lib/rein/constraint/options.rb
+++ b/lib/rein/constraint/options.rb
@@ -1,0 +1,14 @@
+module Rein
+  module Constraint
+    # This module defines methods for handling options command to several constraints.
+    module Options
+      def conditions_with_if(conditions, options = {})
+        if options[:if].present?
+          "NOT (#{options[:if]}) OR (#{conditions})"
+        else
+          conditions
+        end
+      end
+    end
+  end
+end

--- a/lib/rein/constraint/presence.rb
+++ b/lib/rein/constraint/presence.rb
@@ -3,13 +3,11 @@ module Rein
     # This module contains methods for defining presence constraints.
     module Presence
       include ActiveRecord::ConnectionAdapters::Quoting
+      include Rein::Constraint::Options
 
       def add_presence_constraint(table, attribute, options = {})
         name = "#{table}_#{attribute}"
-        conditions = "#{attribute} !~ '^\\s*$'"
-        if options[:if].present?
-          conditions = "NOT (#{options[:if]}) OR (#{conditions})"
-        end
+        conditions = conditions_with_if("#{attribute} !~ '^\\s*$'", options)
         execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
       end
 

--- a/spec/rein/constraint/inclusion_spec.rb
+++ b/spec/rein/constraint/inclusion_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe Rein::Constraint::Inclusion do
       end
     end
 
+    context "given an array of string values and an if option" do
+      it "adds a constraint" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_state CHECK (NOT (deleted_at IS NULL) OR (state IN ('available', 'on_loan')))")
+        adapter.add_inclusion_constraint(:books, :state, in: %w(available on_loan), if: "deleted_at IS NULL")
+      end
+    end
+
     context "given an array of numeric values" do
       it "adds a constraint" do
         expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_state CHECK (state IN (1, 2, 3))")


### PR DESCRIPTION
Btw assuming this gets merged I'd like to add a common `:name` option to support overriding the default constraint name, too. I'd use the `Options` module to implement that.