### PR TITLE
Add setters (generator) for default values

### DIFF
--- a/lib/rein.rb
+++ b/lib/rein.rb
@@ -10,6 +10,8 @@ require "rein/constraint/presence"
 require "rein/type/enum"
 require "rein/view"
 require "rein/schema"
+require "rein/default/generator"
+require "rein/default/gen_random_uuid"
 
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
@@ -34,6 +36,8 @@ module ActiveRecord
       include Rein::Type::Enum
       include Rein::View
       include Rein::Schema
+      include Rein::Default::Generator
+      include Rein::Default::GenRandomUUID
     end
   end
 end

--- a/lib/rein/default/gen_random_uuid.rb
+++ b/lib/rein/default/gen_random_uuid.rb
@@ -1,0 +1,20 @@
+module Rein
+  module Default
+    # This module contains methods for adding default value
+    # using gen_random_uuid() from "pgcrypto" package in v9.4+
+    #
+    # @see https://www.postgresql.org/docs/9.4/static/pgcrypto.html
+    #
+    # @example
+    #   set_default_uuid :products, :sku
+    #
+    module GenRandomUUID
+      include Generator
+
+      def set_default_uuid(table_name, column_name)
+        enable_extension "pgcrypto"
+        set_default_generator table_name, column_name, "gen_random_uuid()"
+      end
+    end
+  end
+end

--- a/lib/rein/default/generator.rb
+++ b/lib/rein/default/generator.rb
@@ -1,0 +1,22 @@
+module Rein
+  module Default
+    # This module contains methods for adding default value
+    # as an arbitrary function
+    #
+    # @example
+    #   set_default_generator :products, :sku, "gen_random_uuid()"
+    #
+    # To remove default use standard syntax from ActiveRecord::Migration library
+    #
+    # @example
+    #   change_column :products, :sku, :string, default: nil
+    #
+    module Generator
+      def set_default_generator(table_name, column_name, default_function)
+        execute "ALTER TABLE #{table_name} " \
+                "ALTER COLUMN #{column_name} " \
+                "SET DEFAULT #{default_function}"
+      end
+    end
+  end
+end

--- a/spec/rein/default/gen_random_uuid_spec.rb
+++ b/spec/rein/default/gen_random_uuid_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe Rein::Default::GenRandomUUID do
+  subject(:adapter) { Class.new { include Rein::Default::GenRandomUUID }.new }
+
+  before { allow(adapter).to receive(:execute) }
+
+  describe "#set_default_uuid" do
+    it "creates an enum type" do
+      expect(adapter).to receive(:enable_extension).with("pgcrypto")
+      expect(adapter)
+        .to receive(:execute)
+        .with("ALTER TABLE products ALTER COLUMN sku SET DEFAULT gen_random_uuid()")
+
+      adapter.set_default_uuid(:products, :sku)
+    end
+  end
+end

--- a/spec/rein/default/generator_spec.rb
+++ b/spec/rein/default/generator_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe Rein::Default::Generator do
+  subject(:adapter) { Class.new { include Rein::Default::Generator }.new }
+
+  before { allow(adapter).to receive(:execute) }
+
+  describe "#set_default_generator" do
+    it "creates an enum type" do
+      expect(adapter)
+        .to receive(:execute)
+        .with("ALTER TABLE products ALTER COLUMN sku SET DEFAULT gen_random_uuid()")
+
+      adapter.set_default_generator(:products, :sku, "gen_random_uuid()")
+    end
+  end
+end


### PR DESCRIPTION
Hi! Thank you for the gem and an approach.

I like the very idea of removing constraints and db-related staff to the database/migration level.

What do you think about extending this approach to other data-related topics like defaults, functions, triggers, etc?

For now I'm extracting defaults from `before_` callbacks to db level in one of our apps, and the PR is a first trial.