### PR TITLE
Length constraint for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,54 @@ add_inclusion_constraint :books, :state,
   name: "books_state_is_valid"
 ```
 
+### Length constraints
+
+A length constraint specifies the range of values that the length of a string
+column value can take.
+
+For example, we can ensure that the `call_number` can only ever be a
+value between 1 and 255:
+
+```ruby
+add_length_constraint :books, :call_number,
+  greater_than_or_equal_to: 1,
+  less_than_or_equal_to: 255
+```
+
+Here's all the options for constraining the values:
+
+- `equal_to`
+- `not_equal_to`
+- `less_than`
+- `less_than_or_equal_to`
+- `greater_than`
+- `greater_than_or_equal_to`
+
+You may also include an `if` option to enforce the constraint only under
+certain conditions, like so:
+
+```ruby
+add_length_constraint :books, :call_number,
+  greater_than_or_equal_to: 1,
+  less_than_or_equal_to: 12,
+  if: "status = 'published'"
+```
+
+You may optionally provide a `name` option to customize the name:
+
+```ruby
+add_length_constraint :books, :call_number,
+  greater_than_or_equal_to: 1,
+  less_than_or_equal_to: 12,
+  name: "books_call_number_is_valid"
+```
+
+To remove a length constraint:
+
+```ruby
+remove_length_constraint :books, :call_number
+```
+
 ### Numericality constraints
 
 A numericality constraint specifies the range of values that a numeric column

--- a/lib/rein.rb
+++ b/lib/rein.rb
@@ -1,6 +1,7 @@
 require "active_record"
 require "rein/constraint/foreign_key"
 require "rein/constraint/inclusion"
+require "rein/constraint/length"
 require "rein/constraint/null"
 require "rein/constraint/numericality"
 require "rein/constraint/presence"
@@ -13,6 +14,7 @@ module ActiveRecord
   class Migration # :nodoc:
     include Rein::Constraint::ForeignKey
     include Rein::Constraint::Inclusion
+    include Rein::Constraint::Length
     include Rein::Constraint::Null
     include Rein::Constraint::Numericality
     include Rein::Constraint::Presence

--- a/lib/rein/constraint/length.rb
+++ b/lib/rein/constraint/length.rb
@@ -1,0 +1,49 @@
+require "rein/util"
+
+module Rein
+  module Constraint
+    # This module contains methods for defining length constraints.
+    module Length
+      OPERATORS = {
+        greater_than: :>,
+        greater_than_or_equal_to: :>=,
+        equal_to: :"=",
+        not_equal_to: :"!=",
+        less_than: :<,
+        less_than_or_equal_to: :<=
+      }.freeze
+
+      def add_length_constraint(*args)
+        reversible do |dir|
+          dir.up { _add_length_constraint(*args) }
+          dir.down { _remove_length_constraint(*args) }
+        end
+      end
+
+      def remove_length_constraint(*args)
+        reversible do |dir|
+          dir.up { _remove_length_constraint(*args) }
+          dir.down { _add_length_constraint(*args) }
+        end
+      end
+
+      private
+
+      def _add_length_constraint(table, attribute, options = {})
+        name = Util.constraint_name(table, attribute, "length", options)
+        attribute_length = "length(#{attribute})"
+        conditions = OPERATORS.slice(*options.keys).map do |key, operator|
+          value = options[key]
+          [attribute_length, operator, value].join(" ")
+        end.join(" AND ")
+        conditions = Util.conditions_with_if(conditions, options)
+        execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
+      end
+
+      def _remove_length_constraint(table, attribute, options = {})
+        name = Util.constraint_name(table, attribute, "length", options)
+        execute("ALTER TABLE #{table} DROP CONSTRAINT #{name}")
+      end
+    end
+  end
+end

--- a/spec/integration/constraints_spec.rb
+++ b/spec/integration/constraints_spec.rb
@@ -50,4 +50,10 @@ RSpec.describe "Constraints" do
     expect { create_book(published_month: 13) }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
     expect { create_book(published_month: 1) }.to_not raise_error
   end
+
+  it "raises an error if the call number length is not between 1 and 255" do
+    expect { create_book(call_number: "") }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
+    expect { create_book(call_number: "K" * 256) }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
+    expect { create_book(call_number: "KF8840 .F72 1999") }.to_not raise_error
+  end
 end

--- a/spec/migrations/2_create_books_table.rb
+++ b/spec/migrations/2_create_books_table.rb
@@ -7,6 +7,7 @@ class CreateBooksTable < ActiveRecord::Migration
       t.integer :published_month, null: false
       t.date :due_date
       t.string :holder
+      t.text :call_number
     end
   end
 end

--- a/spec/migrations/3_add_constraints.rb
+++ b/spec/migrations/3_add_constraints.rb
@@ -6,5 +6,6 @@ class AddConstraints < ActiveRecord::Migration
     add_numericality_constraint :books, :published_month, greater_than_or_equal_to: 1, less_than_or_equal_to: 12
     add_null_constraint :books, :due_date, if: "state = 'on_loan'"
     add_presence_constraint :books, :holder, if: "state = 'on_hold'"
+    add_length_constraint :books, :call_number, greater_than_or_equal_to: 1, less_than_or_equal_to: 255
   end
 end

--- a/spec/rein/constraint/length_spec.rb
+++ b/spec/rein/constraint/length_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+
+RSpec.describe Rein::Constraint::Length do
+  subject(:adapter) do
+    Class.new do
+      include Rein::Constraint::Length
+    end.new
+  end
+
+  let(:dir) { double(up: nil, down: nil) }
+
+  before do
+    allow(dir).to receive(:up).and_yield
+    allow(adapter).to receive(:reversible).and_yield(dir)
+    allow(adapter).to receive(:execute)
+  end
+
+  describe "#add_length_constraint" do
+    context "greater_than" do
+      it "adds a constraint" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) > 1)")
+        adapter.add_length_constraint(:books, :call_number, greater_than: 1)
+      end
+    end
+
+    context "greater_than if" do
+      it "adds a constraint" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (NOT (status = 'published') OR (length(call_number) > 1))")
+        adapter.add_length_constraint(:books, :call_number, greater_than: 1, if: "status = 'published'")
+      end
+    end
+
+    context "greater_than_or_equal_to" do
+      it "adds a constraint" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) >= 2)")
+        adapter.add_length_constraint(:books, :call_number, greater_than_or_equal_to: 2)
+      end
+    end
+
+    context "equal_to" do
+      it "adds a constraint" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) = 3)")
+        adapter.add_length_constraint(:books, :call_number, equal_to: 3)
+      end
+    end
+
+    context "not_equal_to" do
+      it "adds a constraint" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) != 0)")
+        adapter.add_length_constraint(:books, :call_number, not_equal_to: 0)
+      end
+    end
+
+    context "less_than" do
+      it "adds a constraint" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) < 4)")
+        adapter.add_length_constraint(:books, :call_number, less_than: 4)
+      end
+    end
+
+    context "less_than_or_equal_to" do
+      it "adds a constraint" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) <= 5)")
+        adapter.add_length_constraint(:books, :call_number, less_than_or_equal_to: 5)
+      end
+    end
+
+    context "greater_than_or_equal_to and less_than_or_equal_to" do
+      it "adds a constraint" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) >= 5 AND length(call_number) <= 6)")
+        adapter.add_length_constraint(:books, :call_number, greater_than_or_equal_to: 5, less_than_or_equal_to: 6)
+      end
+    end
+
+    context "given a name option" do
+      it "adds a constraint with that name" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) > 1)")
+        adapter.add_length_constraint(:books, :call_number, greater_than: 1, name: "books_call_number_length")
+      end
+    end
+  end
+
+  describe "#remove_length_constraint" do
+    it "removes a constraint" do
+      expect(subject).to receive(:execute).with("ALTER TABLE books DROP CONSTRAINT books_call_number_length")
+      subject.remove_length_constraint(:books, :call_number)
+    end
+  end
+end


### PR DESCRIPTION
Support for length constraints for string columns.

When using some fancy column types such as "citext" in Postgres, you can't specify a length. This changeset allows easy creation of check constraints for string length.