### PR TITLE
Match constraint for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ advantage of reversible Rails migrations.
     * [Foreign key constraints](#foreign-key-constraints)
     * [Inclusion constraints](#inclusion-constraints)
     * [Length constraints](#length-constraints)
+    * [Match constraints](#match-constraints)
     * [Numericality constraints](#numericality-constraints)
     * [Presence constraints](#presence-constraints)
     * [Null constraints](#null-constraints)
@@ -195,6 +196,37 @@ To remove a length constraint:
 remove_length_constraint :books, :call_number
 ```
 
+### Match constraints
+
+A match constraint ensures that a string column value matches (or does not match)
+a POSIX-style regular expression.
+
+For example, we can ensure that the `title` can only contain printable ASCII
+characters, but not ampersands:
+
+```ruby
+add_match_constraint :books, :title, accepts: '\A[ -~]*\Z', rejects: '&'
+```
+
+If you only want to enforce the constraint under certain conditions,
+you can pass an optional `if` option:
+
+```ruby
+add_match_constraint :books, :title, accepts: '\A[ -~]*\Z', if: "status = 'published'"
+```
+
+You may optionally provide a `name` option to customize the name:
+
+```ruby
+add_match_constraint :books, :title, name: "books_title_is_valid"
+```
+
+To remove a match constraint:
+
+```ruby
+remove_match_constraint :books, :title
+```
+
 ### Numericality constraints
 
 A numericality constraint specifies the range of values that a numeric column
@@ -247,8 +279,8 @@ remove_numericality_constraint :books, :publication_month
 
 A presence constraint ensures that a string column value is non-empty.
 
-A `NOT NULL` constraint will be satisfied by an empty string, but sometimes may
-you want to ensure that there is an actual value for a string:
+A `NOT NULL` constraint will be satisfied by an empty string, but sometimes you
+may want to ensure that there is an actual value for a string:
 
 ```ruby
 add_presence_constraint :books, :title

--- a/lib/rein.rb
+++ b/lib/rein.rb
@@ -2,6 +2,7 @@ require "active_record"
 require "rein/constraint/foreign_key"
 require "rein/constraint/inclusion"
 require "rein/constraint/length"
+require "rein/constraint/match"
 require "rein/constraint/null"
 require "rein/constraint/numericality"
 require "rein/constraint/presence"
@@ -15,6 +16,7 @@ module ActiveRecord
     include Rein::Constraint::ForeignKey
     include Rein::Constraint::Inclusion
     include Rein::Constraint::Length
+    include Rein::Constraint::Match
     include Rein::Constraint::Null
     include Rein::Constraint::Numericality
     include Rein::Constraint::Presence

--- a/lib/rein/constraint/match.rb
+++ b/lib/rein/constraint/match.rb
@@ -1,0 +1,46 @@
+require "rein/util"
+
+module Rein
+  module Constraint
+    # This module contains methods for defining regex match constraints.
+    module Match
+      include ActiveRecord::ConnectionAdapters::Quoting
+
+      OPERATORS = {
+        accepts: :~,
+        rejects: :"!~"
+      }.freeze
+
+      def add_match_constraint(*args)
+        reversible do |dir|
+          dir.up { _add_match_constraint(*args) }
+          dir.down { _remove_match_constraint(*args) }
+        end
+      end
+
+      def remove_match_constraint(*args)
+        reversible do |dir|
+          dir.up { _remove_match_constraint(*args) }
+          dir.down { _add_match_constraint(*args) }
+        end
+      end
+
+      private
+
+      def _add_match_constraint(table, attribute, options = {})
+        name = Util.constraint_name(table, attribute, "match", options)
+        conditions = OPERATORS.slice(*options.keys).map do |key, operator|
+          value = options[key]
+          [attribute, operator, "'#{value}'"].join(" ")
+        end.join(" AND ")
+        conditions = Util.conditions_with_if(conditions, options)
+        execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
+      end
+
+      def _remove_match_constraint(table, attribute, options = {})
+        name = Util.constraint_name(table, attribute, "match", options)
+        execute("ALTER TABLE #{table} DROP CONSTRAINT #{name}")
+      end
+    end
+  end
+end

--- a/spec/integration/constraints_spec.rb
+++ b/spec/integration/constraints_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe "Constraints" do
     expect { create_book(title: "On the Origin of Species") }.to_not raise_error
   end
 
+  it "raises an error if the title contains a non-ASCII letter, non-number, or non-whitespace, non-tab character" do
+    expect { create_book(title: "&") }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
+    expect { create_book(title: "\tOn the Origin of Species") }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
+    expect { create_book(title: "On the Origin of Species") }.to_not raise_error
+  end
+
   it "raises an error if the state is invalid" do
     expect { create_book(state: "burned") }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
     expect { create_book(state: "available") }.to_not raise_error

--- a/spec/migrations/3_add_constraints.rb
+++ b/spec/migrations/3_add_constraints.rb
@@ -3,6 +3,7 @@ class AddConstraints < ActiveRecord::Migration
     add_foreign_key_constraint :books, :authors, on_delete: :cascade, index: true
     add_presence_constraint :books, :title
     add_inclusion_constraint :books, :state, in: %w[available on_loan on_hold]
+    add_match_constraint :books, :title, accepts: '\A[a-zA-Z0-9\s]*\Z', rejects: '\t'
     add_numericality_constraint :books, :published_month, greater_than_or_equal_to: 1, less_than_or_equal_to: 12
     add_null_constraint :books, :due_date, if: "state = 'on_loan'"
     add_presence_constraint :books, :holder, if: "state = 'on_hold'"

--- a/spec/rein/constraint/match_spec.rb
+++ b/spec/rein/constraint/match_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+RSpec.describe Rein::Constraint::Match do
+  subject(:adapter) do
+    Class.new do
+      include Rein::Constraint::Match
+    end.new
+  end
+
+  let(:dir) { double(up: nil, down: nil) }
+
+  before do
+    allow(dir).to receive(:up).and_yield
+    allow(adapter).to receive(:reversible).and_yield(dir)
+    allow(adapter).to receive(:execute)
+  end
+
+  describe "#add_match_constraint" do
+    context "accept" do
+      it "adds a constraint" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_match CHECK (title ~ '\\A[a-z0-9]*\\Z')")
+        adapter.add_match_constraint(:books, :title, accepts: '\A[a-z0-9]*\Z')
+      end
+    end
+
+    context "accept if" do
+      it "adds a constraint" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_match CHECK (NOT (status = 'published') OR (title ~ '\\A[a-z0-9]*\\Z'))")
+        adapter.add_match_constraint(:books, :title, accepts: '\A[a-z0-9]*\Z', if: "status = 'published'")
+      end
+    end
+
+    context "reject" do
+      it "adds a constraint" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_match CHECK (title !~ '\\A[a-z0-9]*\\Z')")
+        adapter.add_match_constraint(:books, :title, rejects: '\A[a-z0-9]*\Z')
+      end
+    end
+
+    context "accept and reject" do
+      it "adds a constraint" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_match CHECK (title ~ '\\A[a-z0-9]*\\Z' AND title !~ '\\A[0-9]*\\Z')")
+        adapter.add_match_constraint(:books, :title, accepts: '\A[a-z0-9]*\Z', rejects: '\A[0-9]*\Z')
+      end
+    end
+
+    context "given a name option" do
+      it "adds a constraint with that name" do
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_is_valid CHECK (title ~ '\\A[a-z0-9]*\\Z')")
+        adapter.add_match_constraint(:books, :title, accepts: '\A[a-z0-9]*\Z', name: "books_title_is_valid")
+      end
+    end
+  end
+
+  describe "#remove_match_constraint" do
+    it "removes a constraint" do
+      expect(subject).to receive(:execute).with("ALTER TABLE books DROP CONSTRAINT books_title_match")
+      subject.remove_match_constraint(:books, :title)
+    end
+  end
+end


### PR DESCRIPTION
Support for regex match constraints for string columns.

Sometimes you need a regex-based constraint for strings, because you want to, say, make sure that they match the rules for allowed subdomain characters.