### PR TITLE
Wrap all identifiers in double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,16 @@ class CreateArchivedBooksTable < ActiveRecord::Migration
 end
 ```
 
+## Contribute
+
+* Bundle all gems `bundle`
+* Create the test database `createdb -U <your postgresql username> rein_test`
+* Run the test suite `bundle exec rake`
+* Hack away
+* Rerun test suite
+* Create PR
+
+
 ## License
 
 Rein is licensed under the [MIT License](/LICENSE.md).

--- a/lib/rein/constraint/inclusion.rb
+++ b/lib/rein/constraint/inclusion.rb
@@ -25,6 +25,7 @@ module Rein
       def _add_inclusion_constraint(table, attribute, options = {})
         name = Util.constraint_name(table, attribute, 'inclusion', options)
         values = options[:in].map { |value| quote(value) }.join(', ')
+        attribute = Util.attribute_name(attribute)
         conditions = Util.conditions_with_if("#{attribute} IN (#{values})", options)
         execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
       end

--- a/lib/rein/constraint/length.rb
+++ b/lib/rein/constraint/length.rb
@@ -31,6 +31,7 @@ module Rein
 
       def _add_length_constraint(table, attribute, options = {})
         name = Util.constraint_name(table, attribute, 'length', options)
+        attribute = Util.attribute_name(attribute)
         attribute_length = "length(#{attribute})"
         conditions = OPERATORS.slice(*options.keys).map { |key, operator|
           value = options[key]

--- a/lib/rein/constraint/match.rb
+++ b/lib/rein/constraint/match.rb
@@ -29,6 +29,7 @@ module Rein
 
       def _add_match_constraint(table, attribute, options = {})
         name = Util.constraint_name(table, attribute, 'match', options)
+        attribute = Util.attribute_name(attribute)
         conditions = OPERATORS.slice(*options.keys).map { |key, operator|
           value = options[key]
           [attribute, operator, "'#{value}'"].join(' ')

--- a/lib/rein/constraint/null.rb
+++ b/lib/rein/constraint/null.rb
@@ -24,6 +24,7 @@ module Rein
 
       def _add_null_constraint(table, attribute, options = {})
         name = Util.constraint_name(table, attribute, 'null', options)
+        attribute = Util.attribute_name(attribute)
         conditions = Util.conditions_with_if("#{attribute} IS NOT NULL", options)
         execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
       end

--- a/lib/rein/constraint/numericality.rb
+++ b/lib/rein/constraint/numericality.rb
@@ -31,6 +31,7 @@ module Rein
 
       def _add_numericality_constraint(table, attribute, options = {})
         name = Util.constraint_name(table, attribute, 'numericality', options)
+        attribute = Util.attribute_name(attribute)
         conditions = OPERATORS.slice(*options.keys).map { |key, operator|
           value = options[key]
           [attribute, operator, value].join(' ')

--- a/lib/rein/constraint/presence.rb
+++ b/lib/rein/constraint/presence.rb
@@ -24,6 +24,7 @@ module Rein
 
       def _add_presence_constraint(table, attribute, options = {})
         name = Util.constraint_name(table, attribute, 'presence', options)
+        attribute = Util.attribute_name(attribute)
         conditions = Util.conditions_with_if(
           "(#{attribute} IS NOT NULL) AND (#{attribute} !~ '^\\s*$')",
           options

--- a/lib/rein/constraint/unique.rb
+++ b/lib/rein/constraint/unique.rb
@@ -25,6 +25,7 @@ module Rein
       def _add_unique_constraint(table, attributes, options = {})
         attributes = [attributes].flatten
         name = Util.constraint_name(table, attributes.join('_'), 'unique', options)
+        attributes = attributes.map { |attribute| Util.attribute_name(attribute) }
         initially = options[:deferred] ? 'DEFERRED' : 'IMMEDIATE'
         sql = "ALTER TABLE #{table} ADD CONSTRAINT #{name} UNIQUE (#{attributes.join(', ')})"
         sql << " DEFERRABLE INITIALLY #{initially}" unless options[:deferrable] == false

--- a/lib/rein/util.rb
+++ b/lib/rein/util.rb
@@ -13,6 +13,10 @@ module Rein
       def self.constraint_name(table, attribute, suffix, options = {})
         options[:name].presence || "#{table}_#{attribute}_#{suffix}"
       end
+
+      def self.attribute_name(attribute)
+        "\"#{attribute}\""
+      end
     end
   end
 end

--- a/spec/rein/constraint/inclusion_spec.rb
+++ b/spec/rein/constraint/inclusion_spec.rb
@@ -18,28 +18,28 @@ RSpec.describe Rein::Constraint::Inclusion do
   describe '#add_inclusion_constraint' do
     context 'given an array of string values' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_state_inclusion CHECK (state IN ('available', 'on_loan'))")
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_state_inclusion CHECK (\"state\" IN ('available', 'on_loan'))")
         adapter.add_inclusion_constraint(:books, :state, in: %w[available on_loan])
       end
     end
 
     context 'given an array of string values and an if option' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_state_inclusion CHECK (NOT (deleted_at IS NULL) OR (state IN ('available', 'on_loan')))")
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_state_inclusion CHECK (NOT (deleted_at IS NULL) OR (\"state\" IN ('available', 'on_loan')))")
         adapter.add_inclusion_constraint(:books, :state, in: %w[available on_loan], if: 'deleted_at IS NULL')
       end
     end
 
     context 'given a name option' do
       it 'adds a constraint with that name' do
-        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_state_is_valid CHECK (state IN ('available', 'on_loan'))")
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_state_is_valid CHECK (\"state\" IN ('available', 'on_loan'))")
         adapter.add_inclusion_constraint(:books, :state, in: %w[available on_loan], name: 'books_state_is_valid')
       end
     end
 
     context 'given an array of numeric values' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_state_inclusion CHECK (state IN (1, 2, 3))')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_state_inclusion CHECK ("state" IN (1, 2, 3))')
         adapter.add_inclusion_constraint(:books, :state, in: [1, 2, 3])
       end
     end

--- a/spec/rein/constraint/length_spec.rb
+++ b/spec/rein/constraint/length_spec.rb
@@ -18,63 +18,63 @@ RSpec.describe Rein::Constraint::Length do
   describe '#add_length_constraint' do
     context 'greater_than' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) > 1)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length("call_number") > 1)')
         adapter.add_length_constraint(:books, :call_number, greater_than: 1)
       end
     end
 
     context 'greater_than if' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (NOT (status = 'published') OR (length(call_number) > 1))")
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (NOT (status = 'published') OR (length(\"call_number\") > 1))")
         adapter.add_length_constraint(:books, :call_number, greater_than: 1, if: "status = 'published'")
       end
     end
 
     context 'greater_than_or_equal_to' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) >= 2)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length("call_number") >= 2)')
         adapter.add_length_constraint(:books, :call_number, greater_than_or_equal_to: 2)
       end
     end
 
     context 'equal_to' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) = 3)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length("call_number") = 3)')
         adapter.add_length_constraint(:books, :call_number, equal_to: 3)
       end
     end
 
     context 'not_equal_to' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) != 0)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length("call_number") != 0)')
         adapter.add_length_constraint(:books, :call_number, not_equal_to: 0)
       end
     end
 
     context 'less_than' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) < 4)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length("call_number") < 4)')
         adapter.add_length_constraint(:books, :call_number, less_than: 4)
       end
     end
 
     context 'less_than_or_equal_to' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) <= 5)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length("call_number") <= 5)')
         adapter.add_length_constraint(:books, :call_number, less_than_or_equal_to: 5)
       end
     end
 
     context 'greater_than_or_equal_to and less_than_or_equal_to' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) >= 5 AND length(call_number) <= 6)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length("call_number") >= 5 AND length("call_number") <= 6)')
         adapter.add_length_constraint(:books, :call_number, greater_than_or_equal_to: 5, less_than_or_equal_to: 6)
       end
     end
 
     context 'given a name option' do
       it 'adds a constraint with that name' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length(call_number) > 1)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_length CHECK (length("call_number") > 1)')
         adapter.add_length_constraint(:books, :call_number, greater_than: 1, name: 'books_call_number_length')
       end
     end

--- a/spec/rein/constraint/match_spec.rb
+++ b/spec/rein/constraint/match_spec.rb
@@ -18,35 +18,35 @@ RSpec.describe Rein::Constraint::Match do
   describe '#add_match_constraint' do
     context 'accept' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_match CHECK (title ~ '\\A[a-z0-9]*\\Z')")
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_match CHECK (\"title\" ~ '\\A[a-z0-9]*\\Z')")
         adapter.add_match_constraint(:books, :title, accepts: '\A[a-z0-9]*\Z')
       end
     end
 
     context 'accept if' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_match CHECK (NOT (status = 'published') OR (title ~ '\\A[a-z0-9]*\\Z'))")
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_match CHECK (NOT (status = 'published') OR (\"title\" ~ '\\A[a-z0-9]*\\Z'))")
         adapter.add_match_constraint(:books, :title, accepts: '\A[a-z0-9]*\Z', if: "status = 'published'")
       end
     end
 
     context 'reject' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_match CHECK (title !~ '\\A[a-z0-9]*\\Z')")
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_match CHECK (\"title\" !~ '\\A[a-z0-9]*\\Z')")
         adapter.add_match_constraint(:books, :title, rejects: '\A[a-z0-9]*\Z')
       end
     end
 
     context 'accept and reject' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_match CHECK (title ~ '\\A[a-z0-9]*\\Z' AND title !~ '\\A[0-9]*\\Z')")
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_match CHECK (\"title\" ~ '\\A[a-z0-9]*\\Z' AND \"title\" !~ '\\A[0-9]*\\Z')")
         adapter.add_match_constraint(:books, :title, accepts: '\A[a-z0-9]*\Z', rejects: '\A[0-9]*\Z')
       end
     end
 
     context 'given a name option' do
       it 'adds a constraint with that name' do
-        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_is_valid CHECK (title ~ '\\A[a-z0-9]*\\Z')")
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_title_is_valid CHECK (\"title\" ~ '\\A[a-z0-9]*\\Z')")
         adapter.add_match_constraint(:books, :title, accepts: '\A[a-z0-9]*\Z', name: 'books_title_is_valid')
       end
     end

--- a/spec/rein/constraint/null_spec.rb
+++ b/spec/rein/constraint/null_spec.rb
@@ -18,21 +18,21 @@ RSpec.describe Rein::Constraint::Null do
   describe '#add_null_constraint' do
     context 'given a table and attribute' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_isbn_null CHECK (isbn IS NOT NULL)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_isbn_null CHECK ("isbn" IS NOT NULL)')
         adapter.add_null_constraint(:books, :isbn)
       end
     end
 
     context 'given a table and attribute and if option' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_isbn_null CHECK (NOT (state = 'published') OR (isbn IS NOT NULL))")
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_isbn_null CHECK (NOT (state = 'published') OR (\"isbn\" IS NOT NULL))")
         adapter.add_null_constraint(:books, :isbn, if: "state = 'published'")
       end
     end
 
     context 'given a name option' do
       it 'adds a constraint with that name' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_isbn_is_valid CHECK (isbn IS NOT NULL)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_isbn_is_valid CHECK ("isbn" IS NOT NULL)')
         adapter.add_null_constraint(:books, :isbn, name: 'books_isbn_is_valid')
       end
     end

--- a/spec/rein/constraint/numericality_spec.rb
+++ b/spec/rein/constraint/numericality_spec.rb
@@ -18,63 +18,63 @@ RSpec.describe Rein::Constraint::Numericality do
   describe '#add_numericality_constraint' do
     context 'greater_than' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK (published_month > 1)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK ("published_month" > 1)')
         adapter.add_numericality_constraint(:books, :published_month, greater_than: 1)
       end
     end
 
     context 'greater_than if' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK (NOT (status = 'published') OR (published_month > 1))")
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK (NOT (status = 'published') OR (\"published_month\" > 1))")
         adapter.add_numericality_constraint(:books, :published_month, greater_than: 1, if: "status = 'published'")
       end
     end
 
     context 'greater_than_or_equal_to' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK (published_month >= 2)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK ("published_month" >= 2)')
         adapter.add_numericality_constraint(:books, :published_month, greater_than_or_equal_to: 2)
       end
     end
 
     context 'equal_to' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK (published_month = 3)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK ("published_month" = 3)')
         adapter.add_numericality_constraint(:books, :published_month, equal_to: 3)
       end
     end
 
     context 'not_equal_to' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK (published_month != 0)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK ("published_month" != 0)')
         adapter.add_numericality_constraint(:books, :published_month, not_equal_to: 0)
       end
     end
 
     context 'less_than' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK (published_month < 4)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK ("published_month" < 4)')
         adapter.add_numericality_constraint(:books, :published_month, less_than: 4)
       end
     end
 
     context 'less_than_or_equal_to' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK (published_month <= 5)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK ("published_month" <= 5)')
         adapter.add_numericality_constraint(:books, :published_month, less_than_or_equal_to: 5)
       end
     end
 
     context 'greater_than_or_equal_to and less_than_or_equal_to' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK (published_month >= 5 AND published_month <= 6)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_numericality CHECK ("published_month" >= 5 AND "published_month" <= 6)')
         adapter.add_numericality_constraint(:books, :published_month, greater_than_or_equal_to: 5, less_than_or_equal_to: 6)
       end
     end
 
     context 'given a name option' do
       it 'adds a constraint with that name' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_is_valid CHECK (published_month > 1)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_published_month_is_valid CHECK ("published_month" > 1)')
         adapter.add_numericality_constraint(:books, :published_month, greater_than: 1, name: 'books_published_month_is_valid')
       end
     end

--- a/spec/rein/constraint/presence_spec.rb
+++ b/spec/rein/constraint/presence_spec.rb
@@ -18,21 +18,21 @@ RSpec.describe Rein::Constraint::Presence do
   describe '#add_presence_constraint' do
     context 'given a table and attribute' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_isbn_presence CHECK ((isbn IS NOT NULL) AND (isbn !~ '^\\s*$'))")
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_isbn_presence CHECK ((\"isbn\" IS NOT NULL) AND (\"isbn\" !~ '^\\s*$'))")
         adapter.add_presence_constraint(:books, :isbn)
       end
     end
 
     context 'given a table and attribute and if option' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_isbn_presence CHECK (NOT (state = 'published') OR ((isbn IS NOT NULL) AND (isbn !~ '^\\s*$')))")
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_isbn_presence CHECK (NOT (state = 'published') OR ((\"isbn\" IS NOT NULL) AND (\"isbn\" !~ '^\\s*$')))")
         adapter.add_presence_constraint(:books, :isbn, if: "state = 'published'")
       end
     end
 
     context 'given a name option' do
       it 'adds a constraint with that name' do
-        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_state_is_valid CHECK ((isbn IS NOT NULL) AND (isbn !~ '^\\s*$'))")
+        expect(adapter).to receive(:execute).with("ALTER TABLE books ADD CONSTRAINT books_state_is_valid CHECK ((\"isbn\" IS NOT NULL) AND (\"isbn\" !~ '^\\s*$'))")
         adapter.add_presence_constraint(:books, :isbn, name: 'books_state_is_valid')
       end
     end

--- a/spec/rein/constraint/unique_spec.rb
+++ b/spec/rein/constraint/unique_spec.rb
@@ -18,35 +18,35 @@ RSpec.describe Rein::Constraint::Unique do
   describe '#add_unique_constraint' do
     context 'given an single attribute' do
       it 'adds a constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_unique UNIQUE (call_number) DEFERRABLE INITIALLY IMMEDIATE')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_unique UNIQUE ("call_number") DEFERRABLE INITIALLY IMMEDIATE')
         adapter.add_unique_constraint(:books, :call_number)
       end
     end
 
     context 'given an array of attributes' do
       it 'adds a deferrable constraint that is initially immediate' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_title_unique UNIQUE (call_number, title) DEFERRABLE INITIALLY IMMEDIATE')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_title_unique UNIQUE ("call_number", "title") DEFERRABLE INITIALLY IMMEDIATE')
         adapter.add_unique_constraint(:books, %w[call_number title])
       end
     end
 
     context 'given a name option' do
       it 'adds a constraint with that name' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_is_unique UNIQUE (call_number) DEFERRABLE INITIALLY IMMEDIATE')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_is_unique UNIQUE ("call_number") DEFERRABLE INITIALLY IMMEDIATE')
         adapter.add_unique_constraint(:books, :call_number, name: 'books_call_number_is_unique')
       end
     end
 
     context 'given a deferred option' do
       it 'adds a deferrable constraint that is initially deferred' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_unique UNIQUE (call_number) DEFERRABLE INITIALLY DEFERRED')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_unique UNIQUE ("call_number") DEFERRABLE INITIALLY DEFERRED')
         adapter.add_unique_constraint(:books, :call_number, deferred: true)
       end
     end
 
     context 'given a deferrable option' do
       it 'adds an immediate constraint' do
-        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_unique UNIQUE (call_number)')
+        expect(adapter).to receive(:execute).with('ALTER TABLE books ADD CONSTRAINT books_call_number_unique UNIQUE ("call_number")')
         adapter.add_unique_constraint(:books, :call_number, deferrable: false)
       end
     end


### PR DESCRIPTION
Fixes #34

This was a little more involved than I originally thought.

I am no SQL expert so let me know if this change is problematic.

I noticed that in my rails `structure.sql` the column names are usually not quoted/escaped but the reserved words are escapsed (eg `"from"`). I looked at the active record postgres adapter and noticed https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb#L45-L48, however, I didn't want tie into either the pg gem or active record so I made this naive implementation. I did extract it to a util function so iterating on this should be easy.