### PR TITLE
Handle extra args when dropping Enum Type

### DIFF
--- a/lib/rein/type/enum.rb
+++ b/lib/rein/type/enum.rb
@@ -31,7 +31,7 @@ module Rein
         execute("CREATE TYPE #{enum_name} AS ENUM (#{enum_values})")
       end
 
-      def _drop_enum_type(enum_name)
+      def _drop_enum_type(enum_name, *)
         execute("DROP TYPE #{enum_name}")
       end
     end

--- a/spec/rein/type/enum_spec.rb
+++ b/spec/rein/type/enum_spec.rb
@@ -35,4 +35,11 @@ RSpec.describe Rein::Type::Enum do
       adapter.add_enum_value(:book_type, 'ebook')
     end
   end
+
+  describe '#drop_enum_type via change method on rollback' do
+    it 'drops an enum type' do
+      expect(adapter).to receive(:execute).with('DROP TYPE book_type')
+      adapter.drop_enum_type(:book_type, %w[paperback hardcover])
+    end
+  end
 end


### PR DESCRIPTION
When an Enum is dropped in a rollback the original create is reversed, this results in the _drop_enum_type method being passed the array of types which it wasn't expecting.

This PR adds a test case to handle this and swallows the additional arguments (if present) 