### PR TITLE
Adds support to define extra attribute settings on exclusion constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ a transaction, then you can set the `deferrable` option to `false`:
 add_exclusion_constraint :book_owners, [[:book_id, '='], [:owned_during, '&&']], using: :gist, deferrable: false
 ```
 
+If you want to specify something like a operator class for a attribute specific attribute you can add it to the attribute specification between attribute name and the operator:
+
+```ruby
+add_exclusion_constraint :book_owners, [[:book_id, :gist_int8_ops, '='], [:owned_during, '&&']], using: :gist
+```
+
 ### Inclusion Constraints
 
 An inclusion constraint specifies the possible values that a column value can

--- a/lib/rein/constraint/exclusion.rb
+++ b/lib/rein/constraint/exclusion.rb
@@ -42,13 +42,21 @@ module Rein
         name = Util.constraint_name(table, attributes.map { |att| att[0] }.join('_'), 'exclude', options)
         table = Util.wrap_identifier(table)
         attributes = attributes.map do |attribute|
-          "#{Util.wrap_identifier(attribute[0])} WITH #{attribute[1]}"
+          _get_attribute_expression(attribute)
         end
         initially = options[:deferred] ? 'DEFERRED' : 'IMMEDIATE'
         using = options[:using] ? " USING #{options[:using]}" : ''
         sql = "ALTER TABLE #{table} ADD CONSTRAINT #{name} EXCLUDE#{using} (#{attributes.join(', ')})"
         sql << " DEFERRABLE INITIALLY #{initially}" unless options[:deferrable] == false
         execute(sql)
+      end
+
+      def _get_attribute_expression(attribute)
+        if attribute.size > 2
+          "#{Util.wrap_identifier(attribute[0])} #{attribute[1, attribute.size - 2].join(' ')} WITH #{attribute.last}"
+        else
+          "#{Util.wrap_identifier(attribute[0])} WITH #{attribute[1]}"
+        end
       end
 
       def _remove_exclusion_constraint(table, attributes, options = {})

--- a/spec/rein/constraint/exclusion_spec.rb
+++ b/spec/rein/constraint/exclusion_spec.rb
@@ -50,6 +50,13 @@ RSpec.describe Rein::Constraint::Exclusion do
         adapter.add_exclusion_constraint(:book_owners, :book_id, '=', deferrable: false)
       end
     end
+
+    context 'given attribute options' do
+      it 'adds an constraint with attribute options to specific fields' do
+        expect(adapter).to receive(:execute).with(%(ALTER TABLE "book_owners" ADD CONSTRAINT book_owners_book_id_exclude EXCLUDE ("book_id" gist_int8_ops WITH =) DEFERRABLE INITIALLY IMMEDIATE))
+        adapter.add_exclusion_constraint(:book_owners, [[:book_id, :gist_int8_ops, '=']])
+      end
+    end
   end
 
   describe '#remove_exclusion_constraint' do


### PR DESCRIPTION
Exclusion constraints allow the definition of other settings for a given attribute, like the operator class, similar to what can be done in an index. 
More info [here](https://www.postgresql.org/docs/9.0/static/sql-createtable.html#SQL-CREATETABLE-EXCLUDE).

This pull request tries to add support for this while maintaining the existing syntax to create exclusion constraints.

Thank you