### PR TITLE
Adds support to create a exclusion constraint on a subset of the table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,12 @@ If you want to specify something like a operator class for a attribute specific 
 add_exclusion_constraint :book_owners, [[:book_id, :gist_int8_ops, '='], [:owned_during, '&&']], using: :gist
 ```
 
+If you want to set the constraint to a subset of the table you can use a where option to set the filter condition:
+
+```ruby
+add_exclusion_constraint :books, [[:isbn, '=']], using: :gist, where: "state='active'"
+```
+
 ### Inclusion Constraints
 
 An inclusion constraint specifies the possible values that a column value can

--- a/lib/rein/constraint/exclusion.rb
+++ b/lib/rein/constraint/exclusion.rb
@@ -47,6 +47,7 @@ module Rein
         initially = options[:deferred] ? 'DEFERRED' : 'IMMEDIATE'
         using = options[:using] ? " USING #{options[:using]}" : ''
         sql = "ALTER TABLE #{table} ADD CONSTRAINT #{name} EXCLUDE#{using} (#{attributes.join(', ')})"
+        sql << " WHERE (#{options[:where]})" if options[:where].present?
         sql << " DEFERRABLE INITIALLY #{initially}" unless options[:deferrable] == false
         execute(sql)
       end

--- a/spec/rein/constraint/exclusion_spec.rb
+++ b/spec/rein/constraint/exclusion_spec.rb
@@ -57,6 +57,13 @@ RSpec.describe Rein::Constraint::Exclusion do
         adapter.add_exclusion_constraint(:book_owners, [[:book_id, :gist_int8_ops, '=']])
       end
     end
+
+    context 'given a where option' do
+      it 'adds an contraint using a partial index' do
+        expect(adapter).to receive(:execute).with(%(ALTER TABLE "book" ADD CONSTRAINT book_isbn_exclude EXCLUDE ("isbn" WITH =) WHERE (state='active') DEFERRABLE INITIALLY IMMEDIATE))
+        adapter.add_exclusion_constraint(:book, :isbn, '=', where: "state='active'")
+      end
+    end
   end
 
   describe '#remove_exclusion_constraint' do


### PR DESCRIPTION
Exclusion constraints can be defined for a subset of a table using WHERE and a condition.
More info [here](https://www.postgresql.org/docs/9.1/sql-createtable.html#SQL-CREATETABLE-EXCLUDE).

This pull request tries to add support for this while maintaining the existing syntax to create exclusion constraints.

Thank you