### PR TITLE
Add support for `NOT VALID` constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,11 +500,11 @@ With Rails 5.2 or later, you can use [`validate_constraint`](https://api.rubyonr
 validate_table_constraint :books, "no_r_titles"
 ```
 
-It is safe (a no-op) to validate a constraint that is already marked as valid.
+It's safe (a no-op) to validate a constraint that is already marked as valid.
 
 ### Side note on `lock_timeout`
 
-It's advisable to set a [sensibly low `lock_timeout`](https://gocardless.com/blog/zero-downtime-postgres-migrations-the-hard-parts/) in your database migrations, otherwise existing long running transactions can prevent your migration from acquiring the required locks, resulting in a lock queue that grinds your production database to a halt.
+It's advisable to set a [sensibly low `lock_timeout`](https://gocardless.com/blog/zero-downtime-postgres-migrations-the-hard-parts/) in your database migrations, otherwise existing long-running transactions can prevent your migration from acquiring the required locks, resulting in a lock queue that prevents even selects on the target table, potentially brining your production database grinding to a halt.
 
 ## Data Types
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ advantage of reversible Rails migrations.
 
 * [Getting Started](#getting-started)
 * [Constraint Types](#constraint-types)
+  * [Summary](#summary)
   * [Foreign Key Constraints](#foreign-key-constraints)
   * [Unique Constraints](#unique-constraints)
   * [Exclusion Constraints](#exclusion-constraints)
@@ -29,6 +30,7 @@ advantage of reversible Rails migrations.
   * [Presence Constraints](#presence-constraints)
   * [Null Constraints](#null-constraints)
   * [Check Constraints](#check-constraints)
+  * [Validate Constraints](#validate-constraints)
 * [Data Types](#data-types)
   * [Enumerated Types](#enumerated-types)
 * [Views](#views)
@@ -61,6 +63,23 @@ end
 ```
 
 ## Constraint Types
+
+### Summary
+
+The table below summarises the constraint operations provided by Rein and whether they support [validation](#validate-constraints).
+
+| Rein name   | Rein method | SQL | Supports `NOT VALID`? |
+| ----------- | ----------- | --- | --------------------- |
+| Foreign Key | `add_foreign_key_constraint` | `FOREIGN KEY` | yes |
+| Unique | `add_unique_constraint` | `UNIQUE` | no |
+| Exclusion | `add_exclusion_constraint` | `EXCLUDE` | no |
+| Inclusion | `add_inclusion_constraint` | `CHECK` | yes |
+| Length | `add_length_constraint` | `CHECK]` | yes |
+| Match | `add_match_constraint` | `CHECK]` | yes |
+| Numericality | `add_numericality_constraint` | `CHECK]` | yes |
+| Presence | `add_presence_constraint` | `CHECK]` | yes |
+| Null | `add_null_constraint` | `CHECK]` | yes |
+| Check | `add_check_constraint` | `CHECK]` | yes |
 
 ### Foreign Key Constraints
 
@@ -460,6 +479,28 @@ To remove a check constraint:
 ```ruby
 remove_check_constraint :books, "substring(title FROM 1 FOR 1) IS DISTINCT FROM 'r'", name: 'no_r_titles'
 ```
+
+### Validate Constraints
+
+Adding a constraint can be a very costly operation, especially on larger tables, as the database has to scan all rows in the table to check for violations of the new constraint. During this time, concurrent writes are blocked as an [`ACCESS EXCLUSIVE`](https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-TABLES) lock is taken. In addition, adding a foreign key constraint obtains a `SHARE ROW EXCLUSIVE` lock on the referenced table. See the [docs](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-NOTES) for more details.
+
+In order to allow constraints to be added concurrently on larger tables, and to allow the addition of constraints on tables containing rows with existing violations, Postgres supports adding constraints using the `NOT VALID` option (currently only for `CHECK` and foreign key constraints).
+
+This allows the constraint to be added immediately, without validating existing rows, but enforcing the constraint for any new rows and updates. After that, a `VALIDATE CONSTRAINT` command can be issued to verify that existing rows satisfy the constraint, which is done in a way that does not lock out concurrent updates.
+
+Rein supports adding `CHECK` and foreign key constraints with the `NOT VALID` option by passing `validate: false` to the options of the supported Rein DSL methods, [summarised above](#summary).
+
+```ruby
+add_null_constraint :books, :due_date, if: "state = 'on_loan'", validate: false
+```
+
+With Rails 5.2 or later, you can use [`validate_constraint`](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/PostgreSQL/SchemaStatements.html#method-i-validate_constraint) in a subsequent migration to validate a `NOT VALID` constraint. If you are using versions of Rails below 5.2, you can use Rein's `validate_table_constraint` method:
+
+```ruby
+validate_table_constraint :books, "no_r_titles"
+```
+
+It's safe (a no-op) to validate a constraint that is already marked as valid.
 
 ## Data Types
 

--- a/lib/rein.rb
+++ b/lib/rein.rb
@@ -10,6 +10,7 @@ require 'rein/constraint/presence'
 require 'rein/constraint/primary_key'
 require 'rein/constraint/unique'
 require 'rein/constraint/exclusion'
+require 'rein/constraint/validate'
 require 'rein/schema'
 require 'rein/type/enum'
 require 'rein/view'
@@ -27,6 +28,7 @@ module ActiveRecord
     include Rein::Constraint::PrimaryKey
     include Rein::Constraint::Unique
     include Rein::Constraint::Exclusion
+    include Rein::Constraint::Validate
     include Rein::Schema
     include Rein::Type::Enum
     include Rein::View

--- a/lib/rein/constraint/check.rb
+++ b/lib/rein/constraint/check.rb
@@ -27,7 +27,7 @@ module Rein
         sql = "ALTER TABLE #{Util.wrap_identifier(table_name)}"
         sql << " ADD CONSTRAINT #{name}"
         sql << " CHECK (#{predicate})"
-        execute(sql)
+        execute(Util.add_not_valid_suffix_if_required(sql, options))
       end
 
       def _remove_check_constraint(table_name, _predicate, options = {})

--- a/lib/rein/constraint/foreign_key.rb
+++ b/lib/rein/constraint/foreign_key.rb
@@ -31,7 +31,7 @@ module Rein
         sql << " REFERENCES #{referenced_table} (#{Util.wrap_identifier(referenced_attribute)})"
         sql << " ON DELETE #{referential_action(options[:on_delete])}" if options[:on_delete].present?
         sql << " ON UPDATE #{referential_action(options[:on_update])}" if options[:on_update].present?
-        execute(sql)
+        execute(Util.add_not_valid_suffix_if_required(sql, options))
         add_index(referencing_table, referencing_attribute) if options[:index] == true
       end
 

--- a/lib/rein/constraint/inclusion.rb
+++ b/lib/rein/constraint/inclusion.rb
@@ -28,12 +28,8 @@ module Rein
         values = options[:in].map { |value| quote(value) }.join(', ')
         attribute = Util.wrap_identifier(attribute)
         conditions = Util.conditions_with_if("#{attribute} IN (#{values})", options)
-        execute(
-          Util.add_not_valid_suffix_if_required(
-            "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})",
-            options
-          )
-        )
+        sql = "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})"
+        execute(Util.add_not_valid_suffix_if_required(sql, options))
       end
 
       def _remove_inclusion_constraint(table, attribute, options = {})

--- a/lib/rein/constraint/inclusion.rb
+++ b/lib/rein/constraint/inclusion.rb
@@ -28,7 +28,12 @@ module Rein
         values = options[:in].map { |value| quote(value) }.join(', ')
         attribute = Util.wrap_identifier(attribute)
         conditions = Util.conditions_with_if("#{attribute} IN (#{values})", options)
-        execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
+        execute(
+          Util.add_not_valid_suffix_if_required(
+            "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})",
+            options
+          )
+        )
       end
 
       def _remove_inclusion_constraint(table, attribute, options = {})

--- a/lib/rein/constraint/length.rb
+++ b/lib/rein/constraint/length.rb
@@ -39,7 +39,12 @@ module Rein
           [attribute_length, operator, value].join(' ')
         end.join(' AND ')
         conditions = Util.conditions_with_if(conditions, options)
-        execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
+        execute(
+          Util.add_not_valid_suffix_if_required(
+            "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})",
+            options
+          )
+        )
       end
 
       def _remove_length_constraint(table, attribute, options = {})

--- a/lib/rein/constraint/length.rb
+++ b/lib/rein/constraint/length.rb
@@ -39,12 +39,8 @@ module Rein
           [attribute_length, operator, value].join(' ')
         end.join(' AND ')
         conditions = Util.conditions_with_if(conditions, options)
-        execute(
-          Util.add_not_valid_suffix_if_required(
-            "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})",
-            options
-          )
-        )
+        sql = "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})"
+        execute(Util.add_not_valid_suffix_if_required(sql, options))
       end
 
       def _remove_length_constraint(table, attribute, options = {})

--- a/lib/rein/constraint/match.rb
+++ b/lib/rein/constraint/match.rb
@@ -36,7 +36,12 @@ module Rein
           [attribute, operator, "'#{value}'"].join(' ')
         end.join(' AND ')
         conditions = Util.conditions_with_if(conditions, options)
-        execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
+        execute(
+          Util.add_not_valid_suffix_if_required(
+            "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})",
+            options
+          )
+        )
       end
 
       def _remove_match_constraint(table, attribute, options = {})

--- a/lib/rein/constraint/match.rb
+++ b/lib/rein/constraint/match.rb
@@ -36,12 +36,8 @@ module Rein
           [attribute, operator, "'#{value}'"].join(' ')
         end.join(' AND ')
         conditions = Util.conditions_with_if(conditions, options)
-        execute(
-          Util.add_not_valid_suffix_if_required(
-            "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})",
-            options
-          )
-        )
+        sql = "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})"
+        execute(Util.add_not_valid_suffix_if_required(sql, options))
       end
 
       def _remove_match_constraint(table, attribute, options = {})

--- a/lib/rein/constraint/null.rb
+++ b/lib/rein/constraint/null.rb
@@ -27,7 +27,12 @@ module Rein
         table = Util.wrap_identifier(table)
         attribute = Util.wrap_identifier(attribute)
         conditions = Util.conditions_with_if("#{attribute} IS NOT NULL", options)
-        execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
+        execute(
+          Util.add_not_valid_suffix_if_required(
+            "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})",
+            options
+          )
+        )
       end
 
       def _remove_null_constraint(table, attribute, options = {})

--- a/lib/rein/constraint/null.rb
+++ b/lib/rein/constraint/null.rb
@@ -27,12 +27,8 @@ module Rein
         table = Util.wrap_identifier(table)
         attribute = Util.wrap_identifier(attribute)
         conditions = Util.conditions_with_if("#{attribute} IS NOT NULL", options)
-        execute(
-          Util.add_not_valid_suffix_if_required(
-            "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})",
-            options
-          )
-        )
+        sql = "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})"
+        execute(Util.add_not_valid_suffix_if_required(sql, options))
       end
 
       def _remove_null_constraint(table, attribute, options = {})

--- a/lib/rein/constraint/numericality.rb
+++ b/lib/rein/constraint/numericality.rb
@@ -38,12 +38,8 @@ module Rein
           [attribute, operator, value].join(' ')
         end.join(' AND ')
         conditions = Util.conditions_with_if(conditions, options)
-        execute(
-          Util.add_not_valid_suffix_if_required(
-            "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})",
-            options
-          )
-        )
+        sql = "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})"
+        execute(Util.add_not_valid_suffix_if_required(sql, options))
       end
 
       def _remove_numericality_constraint(table, attribute, options = {})

--- a/lib/rein/constraint/numericality.rb
+++ b/lib/rein/constraint/numericality.rb
@@ -38,7 +38,12 @@ module Rein
           [attribute, operator, value].join(' ')
         end.join(' AND ')
         conditions = Util.conditions_with_if(conditions, options)
-        execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
+        execute(
+          Util.add_not_valid_suffix_if_required(
+            "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})",
+            options
+          )
+        )
       end
 
       def _remove_numericality_constraint(table, attribute, options = {})

--- a/lib/rein/constraint/presence.rb
+++ b/lib/rein/constraint/presence.rb
@@ -30,12 +30,8 @@ module Rein
           "(#{attribute} IS NOT NULL) AND (#{attribute} !~ '^\\s*$')",
           options
         )
-        execute(
-          Util.add_not_valid_suffix_if_required(
-            "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})",
-            options
-          )
-        )
+        sql = "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})"
+        execute(Util.add_not_valid_suffix_if_required(sql, options))
       end
 
       def _remove_presence_constraint(table, attribute, options = {})

--- a/lib/rein/constraint/presence.rb
+++ b/lib/rein/constraint/presence.rb
@@ -30,7 +30,12 @@ module Rein
           "(#{attribute} IS NOT NULL) AND (#{attribute} !~ '^\\s*$')",
           options
         )
-        execute("ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})")
+        execute(
+          Util.add_not_valid_suffix_if_required(
+            "ALTER TABLE #{table} ADD CONSTRAINT #{name} CHECK (#{conditions})",
+            options
+          )
+        )
       end
 
       def _remove_presence_constraint(table, attribute, options = {})

--- a/lib/rein/constraint/validate.rb
+++ b/lib/rein/constraint/validate.rb
@@ -15,7 +15,9 @@ module Rein
         end
       end
 
-      private def _validate_table_constraint(table, constraint_name)
+      private
+
+      def _validate_table_constraint(table, constraint_name)
         execute("ALTER TABLE #{Util.wrap_identifier(table)} VALIDATE CONSTRAINT #{constraint_name}")
       end
     end

--- a/lib/rein/constraint/validate.rb
+++ b/lib/rein/constraint/validate.rb
@@ -1,0 +1,23 @@
+require 'rein/util'
+
+module Rein
+  module Constraint
+    # This module contains methods for validating constraints.
+    module Validate
+      def validate_table_constraint(*args)
+        reversible do |dir|
+          dir.up { _validate_table_constraint(*args) }
+          dir.down do
+            # No-op - it's safe to validate an already validated constraint
+            # https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-NOTES
+            # "Nothing happens if the constraint is already marked valid."
+          end
+        end
+      end
+
+      private def _validate_table_constraint(table, constraint_name)
+        execute("ALTER TABLE #{Util.wrap_identifier(table)} VALIDATE CONSTRAINT #{constraint_name}")
+      end
+    end
+  end
+end

--- a/lib/rein/util.rb
+++ b/lib/rein/util.rb
@@ -1,6 +1,12 @@
 module Rein
   # The {Util} module provides utility methods for handling options.
   module Util
+    # Returns a new string with the suffix appended if required
+    def self.add_not_valid_suffix_if_required(sql, options)
+      suffix = options[:validate] == false ? ' NOT VALID' : ''
+      "#{sql}#{suffix}"
+    end
+
     def self.conditions_with_if(conditions, options = {})
       if options[:if].present?
         "NOT (#{options[:if]}) OR (#{conditions})"

--- a/spec/migrations/4_add_constraints.rb
+++ b/spec/migrations/4_add_constraints.rb
@@ -1,15 +1,34 @@
 class AddConstraints < Migration
   def change
-    add_check_constraint :books, "substring(title FROM 1 FOR 1) IS DISTINCT FROM 'r'", name: 'no_r_titles'
-    add_foreign_key_constraint :books, :authors, on_delete: :cascade, index: true
+    add_check_constraint :books, "substring(title FROM 1 FOR 1) IS DISTINCT FROM 'r'", name: 'no_r_titles', validate: false
+    validate_table_constraint :books, 'no_r_titles'
+
+    add_foreign_key_constraint :books, :authors, on_delete: :cascade, index: true, validate: false
+    validate_table_constraint :books, 'books_author_id_fk'
+
     add_unique_constraint :books, :isbn
+
     add_exclusion_constraint :book_owners, [[:book_id, '=']]
-    add_presence_constraint :books, :title
-    add_inclusion_constraint :books, :state, in: %w[available on_loan on_hold]
-    add_match_constraint :books, :title, accepts: '\A[a-zA-Z0-9\s]*\Z', rejects: '\t'
-    add_numericality_constraint :books, :published_month, greater_than_or_equal_to: 1, less_than_or_equal_to: 12
-    add_null_constraint :books, :due_date, if: "state = 'on_loan'"
-    add_presence_constraint :books, :holder, if: "state = 'on_hold'"
-    add_length_constraint :books, :call_number, greater_than_or_equal_to: 1, less_than_or_equal_to: 255
+
+    add_presence_constraint :books, :title, validate: false
+    validate_table_constraint :books, 'books_title_presence'
+
+    add_inclusion_constraint :books, :state, in: %w[available on_loan on_hold], validate: false
+    validate_table_constraint :books, 'books_state_inclusion'
+
+    add_match_constraint :books, :title, accepts: '\A[a-zA-Z0-9\s]*\Z', rejects: '\t', validate: false
+    validate_table_constraint :books, 'books_title_match'
+
+    add_numericality_constraint :books, :published_month, greater_than_or_equal_to: 1, less_than_or_equal_to: 12, validate: false
+    validate_table_constraint :books, 'books_published_month_numericality'
+
+    add_null_constraint :books, :due_date, if: "state = 'on_loan'", validate: false
+    validate_table_constraint :books, 'books_due_date_null'
+
+    add_presence_constraint :books, :holder, if: "state = 'on_hold'", validate: false
+    validate_table_constraint :books, 'books_holder_presence'
+
+    add_length_constraint :books, :call_number, greater_than_or_equal_to: 1, less_than_or_equal_to: 255, validate: false
+    validate_table_constraint :books, 'books_call_number_length'
   end
 end

--- a/spec/rein/constraint/check_spec.rb
+++ b/spec/rein/constraint/check_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe Rein::Constraint::Check do
         adapter.add_check_constraint(:books, "substring(title FROM 1 FOR 1) IS DISTINCT FROM 'r'", name: 'no_r_titles')
       end
     end
+
+    context 'with a validate option of false' do
+      it 'adds a constraint with NOT VALID' do
+        expect(adapter).to receive(:execute).with(%(ALTER TABLE "books" ADD CONSTRAINT "no_r_titles" CHECK (substring(title FROM 1 FOR 1) IS DISTINCT FROM 'r') NOT VALID))
+        adapter.add_check_constraint(:books, "substring(title FROM 1 FOR 1) IS DISTINCT FROM 'r'", name: 'no_r_titles', validate: false)
+      end
+    end
   end
 
   describe '#remove_check_constraint' do

--- a/spec/rein/constraint/foreign_key_spec.rb
+++ b/spec/rein/constraint/foreign_key_spec.rb
@@ -83,6 +83,13 @@ RSpec.describe Rein::Constraint::ForeignKey do
       end
     end
 
+    context 'with a validate option of false' do
+      it 'adds a constraint with NOT VALID' do
+        expect(adapter).to receive(:execute).with(%(ALTER TABLE "books" ADD CONSTRAINT books_person_id_fk FOREIGN KEY ("person_id") REFERENCES people ("id") ON DELETE NO ACTION ON UPDATE NO ACTION NOT VALID))
+        adapter.add_foreign_key_constraint(:books, :people, on_delete: :no_action, on_update: :no_action, validate: false)
+      end
+    end
+
     describe 'with an index option' do
       it 'adds a constraint' do
         expect(adapter).to receive(:add_index).with(:books, :person_id)

--- a/spec/rein/constraint/inclusion_spec.rb
+++ b/spec/rein/constraint/inclusion_spec.rb
@@ -43,6 +43,13 @@ RSpec.describe Rein::Constraint::Inclusion do
         adapter.add_inclusion_constraint(:books, :state, in: [1, 2, 3])
       end
     end
+
+    context 'with a validate option of false' do
+      it 'adds a constraint with NOT VALID' do
+        expect(adapter).to receive(:execute).with(%(ALTER TABLE "books" ADD CONSTRAINT books_state_inclusion CHECK ("state" IN (1, 2, 3)) NOT VALID))
+        adapter.add_inclusion_constraint(:books, :state, in: [1, 2, 3], validate: false)
+      end
+    end
   end
 
   describe '#remove_inclusion_constraint' do

--- a/spec/rein/constraint/length_spec.rb
+++ b/spec/rein/constraint/length_spec.rb
@@ -78,6 +78,13 @@ RSpec.describe Rein::Constraint::Length do
         adapter.add_length_constraint(:books, :call_number, greater_than: 1, name: 'books_call_number_length')
       end
     end
+
+    context 'with a validate option of false' do
+      it 'adds a constraint with NOT VALID' do
+        expect(adapter).to receive(:execute).with(%(ALTER TABLE "books" ADD CONSTRAINT books_call_number_length CHECK (length("call_number") > 1) NOT VALID))
+        adapter.add_length_constraint(:books, :call_number, greater_than: 1, name: 'books_call_number_length', validate: false)
+      end
+    end
   end
 
   describe '#remove_length_constraint' do

--- a/spec/rein/constraint/match_spec.rb
+++ b/spec/rein/constraint/match_spec.rb
@@ -50,6 +50,13 @@ RSpec.describe Rein::Constraint::Match do
         adapter.add_match_constraint(:books, :title, accepts: '\A[a-z0-9]*\Z', name: 'books_title_is_valid')
       end
     end
+
+    context 'with a validate option of false' do
+      it 'adds a constraint with NOT VALID' do
+        expect(adapter).to receive(:execute).with(%(ALTER TABLE "books" ADD CONSTRAINT books_title_is_valid CHECK (\"title\" ~ '\\A[a-z0-9]*\\Z') NOT VALID))
+        adapter.add_match_constraint(:books, :title, accepts: '\A[a-z0-9]*\Z', name: 'books_title_is_valid', validate: false)
+      end
+    end
   end
 
   describe '#remove_match_constraint' do

--- a/spec/rein/constraint/null_spec.rb
+++ b/spec/rein/constraint/null_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe Rein::Constraint::Null do
         adapter.add_null_constraint(:books, :isbn, name: 'books_isbn_is_valid')
       end
     end
+
+    context 'given a validate option of false' do
+      it 'adds a constraint with NOT VALID' do
+        expect(adapter).to receive(:execute).with(%(ALTER TABLE "books" ADD CONSTRAINT books_isbn_null CHECK ("isbn" IS NOT NULL) NOT VALID))
+        adapter.add_null_constraint(:books, :isbn, validate: false)
+      end
+    end
   end
 
   describe '#remove_null_constraint' do

--- a/spec/rein/constraint/numericality_spec.rb
+++ b/spec/rein/constraint/numericality_spec.rb
@@ -78,6 +78,13 @@ RSpec.describe Rein::Constraint::Numericality do
         adapter.add_numericality_constraint(:books, :published_month, greater_than: 1, name: 'books_published_month_is_valid')
       end
     end
+
+    context 'given a validate option of false' do
+      it 'adds a constraint with NOT VALID' do
+        expect(adapter).to receive(:execute).with(%(ALTER TABLE "books" ADD CONSTRAINT books_published_month_is_valid CHECK ("published_month" > 1) NOT VALID))
+        adapter.add_numericality_constraint(:books, :published_month, greater_than: 1, name: 'books_published_month_is_valid', validate: false)
+      end
+    end
   end
 
   describe '#remove_numericality_constraint' do

--- a/spec/rein/constraint/presence_spec.rb
+++ b/spec/rein/constraint/presence_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe Rein::Constraint::Presence do
         adapter.add_presence_constraint(:books, :isbn, name: 'books_state_is_valid')
       end
     end
+
+    context 'given a validate option of false' do
+      it 'adds a constraint with NOT VALID' do
+        expect(adapter).to receive(:execute).with(%(ALTER TABLE "books" ADD CONSTRAINT books_state_is_valid CHECK ((\"isbn\" IS NOT NULL) AND (\"isbn\" !~ '^\\s*$')) NOT VALID))
+        adapter.add_presence_constraint(:books, :isbn, name: 'books_state_is_valid', validate: false)
+      end
+    end
   end
 
   describe '#remove_presence_constraint' do

--- a/spec/rein/constraint/validate_spec.rb
+++ b/spec/rein/constraint/validate_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe Rein::Constraint::Validate do
+  subject(:adapter) do
+    Class.new do
+      include Rein::Constraint::Validate
+    end.new
+  end
+
+  let(:dir) { double(up: nil, down: nil) }
+
+  before do
+    allow(dir).to receive(:up).and_yield
+    allow(adapter).to receive(:reversible).and_yield(dir)
+    allow(adapter).to receive(:execute)
+  end
+
+  describe '#validate_table_constraint' do
+    it 'validates a constraint' do
+      expect(adapter).to receive(:execute).with(%(ALTER TABLE "books" VALIDATE CONSTRAINT no_r_titles))
+      adapter.validate_table_constraint(:books, 'no_r_titles')
+    end
+  end
+end

--- a/spec/rein/util_spec.rb
+++ b/spec/rein/util_spec.rb
@@ -1,6 +1,22 @@
 require 'spec_helper'
 
 RSpec.describe Rein::Util do
+  describe '.add_not_valid_suffix_if_required' do
+    let(:sql) { '' }
+
+    it 'adds the suffix if validate is false' do
+      expect(
+        described_class.add_not_valid_suffix_if_required(sql, validate: false)
+      ).to eq ' NOT VALID'
+    end
+
+    it 'does not add the suffix if validate is not provided' do
+      expect(
+        described_class.add_not_valid_suffix_if_required(sql, {})
+      ).to eq sql
+    end
+  end
+
   describe '.wrap_identifier' do
     it 'wraps identifiers' do
       expect(Rein::Util.wrap_identifier('foo')).to eq('"foo"')


### PR DESCRIPTION
Fixes #47 and adds support for passing `validate: false` to the options of supported Rein DSL methods. This includes `CHECK` and foreign key constraints and results in the addition of `NOT VALID` to the generated SQL.
