### PR TITLE
Add case-insensitive match constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add `accepts_case_insensitive` and `rejects_case_insensitive` options to match constraints
+
 ## 5.1.0 (2020-01-08)
 
 * Add validate option to foreign key and check constraints

--- a/README.md
+++ b/README.md
@@ -344,6 +344,10 @@ characters, but not ampersands:
 add_match_constraint :books, :title, accepts: '\A[ -~]*\Z', rejects: '&'
 ```
 
+Match constraints are case-sensitive. You make them case-insensitive by using 
+`accepts_case_insensitive` and `rejects_case_insensitive` instead of `accepts` 
+or `rejects`.
+
 If you only want to enforce the constraint under certain conditions,
 you can pass an optional `if` option:
 

--- a/lib/rein/constraint/match.rb
+++ b/lib/rein/constraint/match.rb
@@ -8,7 +8,9 @@ module Rein
 
       OPERATORS = {
         accepts: :~,
-        rejects: :"!~"
+        accepts_case_insensitive: :"~*",
+        rejects: :"!~",
+        rejects_case_insensitive: :"!~*"
       }.freeze
 
       def add_match_constraint(*args)

--- a/spec/rein/constraint/match_spec.rb
+++ b/spec/rein/constraint/match_spec.rb
@@ -30,10 +30,24 @@ RSpec.describe Rein::Constraint::Match do
       end
     end
 
+    context 'accept_case_insensitive' do
+      it 'adds a constraint' do
+        expect(adapter).to receive(:execute).with(%(ALTER TABLE "books" ADD CONSTRAINT books_title_match CHECK (\"title\" ~* '\\A[a-z0-9]*\\Z')))
+        adapter.add_match_constraint(:books, :title, accepts_case_insensitive: '\A[a-z0-9]*\Z')
+      end
+    end
+
     context 'reject' do
       it 'adds a constraint' do
         expect(adapter).to receive(:execute).with(%(ALTER TABLE "books" ADD CONSTRAINT books_title_match CHECK (\"title\" !~ '\\A[a-z0-9]*\\Z')))
         adapter.add_match_constraint(:books, :title, rejects: '\A[a-z0-9]*\Z')
+      end
+    end
+
+    context 'reject_case_insensitive' do
+      it 'adds a constraint' do
+        expect(adapter).to receive(:execute).with(%(ALTER TABLE "books" ADD CONSTRAINT books_title_match CHECK (\"title\" !~* '\\A[a-z0-9]*\\Z')))
+        adapter.add_match_constraint(:books, :title, rejects_case_insensitive: '\A[a-z0-9]*\Z')
       end
     end
 


### PR DESCRIPTION
Currently, all match constraints are case-insensitive, but there is no way of specifying case-insensitivity easily, as a different matching operator is used.

This PR adds the options `accepts_case_insensitive` and `rejects_case_insensitive`, which just provide the `~*` and `!~*` operators, respectively.